### PR TITLE
Add commands to close a tab and control which tab subsequently receives focus

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -71,7 +71,11 @@
     "46-opensettings": {"description": "LOCATION: Open Settings Page"},
     "47-openextensions": {"description": "LOCATION: Open Extensions Page"},
     "48-openshortcuts": {"description": "LOCATION: Open Keyboard Shortcuts Page"},
-    "49-showlatestdownload": {"description": "DOWNLOADS: Show latest download"}
+    "49-showlatestdownload": {"description": "DOWNLOADS: Show latest download"},
+    "50-closetabmovetonext": {"description": "TABS: Close tab and move to next tab"},
+    "51-closetabmovetoprev": {"description": "TABS: Close tab and move to previous tab"},
+    "52-closetabmovetofirst": {"description": "TABS: Close tab and move to first tab"},
+    "53-closetabmovetolast": {"description": "TABS: Close tab and move to last tab"}
   },
   "options_ui": {
     "page": "options/options.html",

--- a/app/options/options.vue
+++ b/app/options/options.vue
@@ -313,6 +313,10 @@ export default {
                     {value: 'movetabright', label: 'Move tab right', builtin: true},
                     {value: 'movetabtofirst', label: 'Move tab to first position', builtin: true},
                     {value: 'movetabtolast', label: 'Move tab to last position', builtin: true},
+                    {value: 'closetabmovetonext', label: 'Close tab and move to next tab', builtin: true},
+                    {value: 'closetabmovetoprev', label: 'Close tab and move to previous tab', builtin: true},
+                    {value: 'closetabmovetofirst', label: 'Close tab and move to first tab', builtin: true},
+                    {value: 'closetabmovetolast', label: 'Close tab and move to last tab', builtin: true},
                 ],
                 'Windows': [
                     {value: 'newwindow', label: 'New window', builtin: true},


### PR DESCRIPTION
I often want to close the current tab and end up on the tab immediately to the left/right.  Currently this can only be done as two separate actions, either:

1. move to the desired tab, and then click the 'x' for the old one, or
2. close the current tab, and then navigate to the desired tab (if necessary).

Both of these are clunky workarounds.

This patch adds commands to close the current tab and also specify which tab should subsequently receive focus.  Specifically:

- Close tab and move to next tab
- Close tab and move to previous tab
- Close tab and move to first tab
- Close tab and move to last tab