### PR TITLE
Use userScripts API for JavaScript actions

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -125,9 +125,11 @@
     "debugger",
     "scripting",
     "notifications",
-    "activeTab"
+    "activeTab",
+    "userScripts"
   ],
   "host_permissions": ["*://*/*"],
+  "user_scripts": { },
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline' https://cdn.materialdesignicons.com https://cdn.jsdelivr.net;"
   },

--- a/app/options/options.vue
+++ b/app/options/options.vue
@@ -39,6 +39,14 @@
 
         <b-tabs v-model="activeTab" type="is-toggle" expanded>
             <b-tab-item label="Shortcuts">
+                <b-message
+                    title="Enable Developer Mode"
+                    type="is-warning"
+                    :active="needsDeveloperMode()"
+                    :closable="false">
+                    In order for JavaScript actions to work, you must first enable Developer Mode in your browser extension settings. Follow the instructions <a href="https://developer.chrome.com/docs/extensions/reference/api/userScripts#developer_mode_for_extension_users" target="_blank">here</a>, then come back and save your shortcuts.
+                </b-message>
+
                 <b-table
                         :data="keys"
                         ref="table"
@@ -196,6 +204,7 @@
 </template>
 
 <script>
+import { v4 as uuid } from "uuid";
 import TextInput from "./components/TextInput";
 import LinkBar from "./components/LinkBar";
 import SelectInput from "./components/SelectInput";
@@ -211,8 +220,25 @@ export default {
         TextInput,
     },
     methods: {
+        needsDeveloperMode: function() {
+            const hasJsKeys = this.keys.some(key => key.action === 'javascript');
+            if (!hasJsKeys) {
+                return false;
+            }
+
+            try {
+                chrome.userScripts;
+                return false;
+            } catch {
+                return true;
+            }
+        },
         saveShortcuts: async function() {
             this.keys.forEach((key) => {
+                if (!key.id) {
+                    key.id = uuid();
+                }
+
                 key.sites = key.sites || "";
                 key.sitesArray = key.sites.split('\n');
                 delete key.sidebarOpen;

--- a/app/scripts/content.js
+++ b/app/scripts/content.js
@@ -1,7 +1,6 @@
 'use strict'
 /* global Mousetrap */
 import Mousetrap from 'mousetrap'
-import './inject-scripts/inject.js'
 
 if (typeof browser === "undefined") {
   var browser = chrome;
@@ -45,7 +44,7 @@ Shortkeys.doAction = (keySetting) => {
     // to the page MAIN world and dispatch this event from the content script
     if (action === 'javascript') {
         document.dispatchEvent(new CustomEvent('shortkeys_js_run', {
-          detail: keySetting.code // code to run
+            detail: keySetting.id
         }))
         return
     } else if (action === 'trigger') {

--- a/app/scripts/inject-scripts/inject.js
+++ b/app/scripts/inject-scripts/inject.js
@@ -1,8 +1,0 @@
-function injectScript (src) {
-    const s = document.createElement('script');
-    s.src = chrome.runtime.getURL(src);
-    //s.onload = () => {console.log('removed'); s.remove()};
-    (document.head || document.documentElement).append(s);
-}
-
-injectScript('scripts/script-to-inject.js')

--- a/app/scripts/inject-scripts/script-to-inject.js
+++ b/app/scripts/inject-scripts/script-to-inject.js
@@ -1,7 +1,0 @@
-document.addEventListener('shortkeys_js_run', function(e) {
-    let script = document.createElement('script')
-    script.textContent = e.detail
-    document.body.appendChild(script)
-    document.body.removeChild(script)
-});
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "mousetrap": "^1.6.3",
         "serialize-javascript": ">=2.1.1",
         "style-loader": "^1.0.1",
+        "uuid": "^10.0.0",
         "vue": "^2.6.11",
         "vue-loader": "^15.8.3",
         "vue-template-compiler": "^2.6.11",
@@ -25,7 +26,7 @@
         "webpack": "^5.89.0"
       },
       "devDependencies": {
-        "@types/chrome": "^0.0.133",
+        "@types/chrome": "^0.0.267",
         "@webextension-toolbox/webextension-toolbox": "^6.2.0"
       }
     },
@@ -1932,9 +1933,9 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.0.133",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.133.tgz",
-      "integrity": "sha512-G8uIUdaCTBILprQvQXBWGXZxjAWbkCkFQit17cdH3zYQEwU8f/etNl8+M7e8MRz9Xj8daHaVpysneMZMx8/ldQ==",
+      "version": "0.0.267",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.267.tgz",
+      "integrity": "sha512-vnCWPpYjazSPRMNmybRH+0q4f738F+Pbbls4ZPFsPr9/4TTNJyK1OLZDpSnghnEWb4stfmIUtq/GegnlfD4sPA==",
       "dev": true,
       "dependencies": {
         "@types/filesystem": "*",
@@ -6058,6 +6059,15 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -6745,10 +6755,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -8598,9 +8611,9 @@
       }
     },
     "@types/chrome": {
-      "version": "0.0.133",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.133.tgz",
-      "integrity": "sha512-G8uIUdaCTBILprQvQXBWGXZxjAWbkCkFQit17cdH3zYQEwU8f/etNl8+M7e8MRz9Xj8daHaVpysneMZMx8/ldQ==",
+      "version": "0.0.267",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.267.tgz",
+      "integrity": "sha512-vnCWPpYjazSPRMNmybRH+0q4f738F+Pbbls4ZPFsPr9/4TTNJyK1OLZDpSnghnEWb4stfmIUtq/GegnlfD4sPA==",
       "dev": true,
       "requires": {
         "@types/filesystem": "*",
@@ -11770,6 +11783,14 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "source-map": {
@@ -12252,10 +12273,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "webextension-toolbox build"
   },
   "devDependencies": {
-    "@types/chrome": "^0.0.133",
+    "@types/chrome": "^0.0.267",
     "@webextension-toolbox/webextension-toolbox": "^6.2.0"
   },
   "dependencies": {
@@ -21,6 +21,7 @@
     "mousetrap": "^1.6.3",
     "serialize-javascript": ">=2.1.1",
     "style-loader": "^1.0.1",
+    "uuid": "^10.0.0",
     "vue": "^2.6.11",
     "vue-loader": "^15.8.3",
     "vue-template-compiler": "^2.6.11",

--- a/webextension-toolbox.config.js
+++ b/webextension-toolbox.config.js
@@ -12,7 +12,6 @@ module.exports = {
 
         config.entry = {
             'scripts/service_worker': './scripts/service_worker.js',
-            'scripts/script-to-inject': './scripts/inject-scripts/script-to-inject.js',
             'scripts/content': './scripts/content.js',
             'options/options': './options/options.js',
         };


### PR DESCRIPTION
This fixes #599.

The implementation is mostly complete (if a bit sloppy), but there is one missing piece: as part of this change, IDs for each shortcut are introduced. Shortcuts with missing IDs will be added on next save. This means users will need to go to the config page at least once before their JS shortcuts will work.

It's possible to perform this migration on extension update but I'm not sure how you wanted to go about it.