### PR TITLE
feat: community pack marketplace (#702)

### DIFF
--- a/.github/ISSUE_TEMPLATE/community-pack.yml
+++ b/.github/ISSUE_TEMPLATE/community-pack.yml
@@ -1,0 +1,100 @@
+name: Community Pack Submission
+description: Submit a new community shortcut pack for Shortkeys
+title: "Community pack: "
+labels: ["community-pack"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing a community pack! Fill in the details below and paste your pack JSON.
+
+        **Tip:** You can auto-generate this from Shortkeys by right-clicking a group → "Publish to community".
+
+  - type: input
+    id: pack-name
+    attributes:
+      label: Pack name
+      placeholder: e.g. Focus Mode
+    validations:
+      required: true
+
+  - type: input
+    id: author
+    attributes:
+      label: Author
+      description: Your GitHub username
+      placeholder: e.g. octocat
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: 1-2 sentences about what this pack does
+      placeholder: e.g. Minimize distractions while working. Close unneeded tabs, mute audio, and keep your workspace clean.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - productivity
+        - navigation
+        - accessibility
+        - developer
+        - media
+        - reading
+        - uncategorized
+    validations:
+      required: true
+
+  - type: input
+    id: icon
+    attributes:
+      label: Icon
+      description: A single emoji
+      placeholder: e.g. 🎯
+    validations:
+      required: true
+
+  - type: input
+    id: color
+    attributes:
+      label: Card color
+      description: Hex color for the pack card in the UI
+      placeholder: e.g. #7c3aed
+    validations:
+      required: true
+
+  - type: input
+    id: tags
+    attributes:
+      label: Tags
+      description: Comma-separated keywords for search
+      placeholder: e.g. focus, productivity, clean
+    validations:
+      required: true
+
+  - type: textarea
+    id: pack-json
+    attributes:
+      label: Pack JSON
+      description: Paste the full pack JSON here. See [contributing guide](https://github.com/crittermike/shortkeys/blob/master/community-packs/README.md) for format.
+      render: json
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I've tested all shortcuts in this pack
+          required: true
+        - label: This pack doesn't duplicate built-in packs or website shortcuts
+          required: true
+        - label: Labels use sentence case
+          required: true

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ tests/setup.js
 .wxt
 .output
 site/catalog.json
+site/community.json
 site/images/
 screenshots/
 playwright-report/

--- a/community-packs/README.md
+++ b/community-packs/README.md
@@ -1,0 +1,88 @@
+# Contributing Community Packs
+
+Community packs are user-contributed shortcut collections that anyone can install from the Import tab in Shortkeys.
+
+## How to submit a pack
+
+1. **Create your shortcuts** in Shortkeys and organize them into a group
+2. **Right-click the group** → "Publish to community" to auto-generate a submission
+3. **Fill in the details** (description, author, icon, category, tags) in the GitHub issue
+4. A maintainer will review your submission and create a PR
+
+Or submit manually:
+
+1. Fork this repository
+2. Create a JSON file in `community-packs/` (see format below)
+3. Open a pull request
+
+## Pack format
+
+Each pack is a single JSON file in the `community-packs/` directory:
+
+```json
+{
+  "id": "community-your-pack-name",
+  "name": "Your Pack Name",
+  "icon": "🎯",
+  "description": "A short description of what this pack does.",
+  "color": "#7c3aed",
+  "author": "your-github-username",
+  "category": "productivity",
+  "tags": ["tag1", "tag2"],
+  "shortcuts": [
+    { "key": "alt+shift+f", "action": "onlytab", "label": "Close all other tabs" },
+    { "key": "alt+shift+m", "action": "togglemute", "label": "Mute/unmute current tab" }
+  ]
+}
+```
+
+### Required fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique ID, must start with `community-` |
+| `name` | string | Display name for the pack |
+| `icon` | string | Single emoji |
+| `description` | string | Short description (1-2 sentences) |
+| `color` | string | Hex color for the pack card |
+| `author` | string | Your GitHub username |
+| `category` | string | One of: `productivity`, `navigation`, `accessibility`, `developer`, `media`, `reading`, `uncategorized` |
+| `tags` | string[] | Relevant keywords for search |
+| `shortcuts` | array | Array of shortcut objects |
+
+### Shortcut fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | string | Keyboard shortcut (e.g. `alt+shift+f`) |
+| `action` | string | Action ID from the [actions registry](../src/utils/actions-registry.ts) |
+| `label` | string | Human-readable description |
+| `code` | string | (Optional) JavaScript code, only for `javascript` actions |
+
+## Guidelines
+
+- **Don't duplicate built-in packs** — check `src/packs/` for existing Vim, Emacs, YouTube, etc. packs
+- **Don't duplicate website shortcuts** — if a site already has keyboard shortcuts (Gmail, GitHub, etc.), don't recreate them
+- **Use sentence case for labels** — "Close all other tabs" not "Close All Other Tabs"
+- **Keep packs focused** — 4-12 shortcuts is ideal, avoid kitchen-sink packs
+- **Test your shortcuts** — make sure every shortcut works before submitting
+- **JavaScript actions require extra review** — packs with `code` fields will show a security warning to users before install
+
+## Categories
+
+| Category | Description |
+|----------|-------------|
+| `productivity` | Workflow optimization, tab management, focus tools |
+| `navigation` | Page scrolling, link navigation, history |
+| `accessibility` | Font size, contrast, screen reader helpers |
+| `developer` | DevTools, console, debugging shortcuts |
+| `media` | Video/audio controls, playback |
+| `reading` | Read mode, text formatting, bookmarks |
+| `uncategorized` | Everything else |
+
+## What happens after you submit
+
+1. A maintainer reviews your pack for quality and security
+2. If approved, it's merged into the `community-packs/` directory
+3. On the next site build, your pack appears in the community catalog
+4. Users can discover and install it from the Import tab

--- a/community-packs/accessibility.json
+++ b/community-packs/accessibility.json
@@ -1,0 +1,19 @@
+{
+  "id": "community-accessibility",
+  "name": "Accessibility",
+  "icon": "♿",
+  "description": "Quick access to zoom controls, text tools, and navigation aids for comfortable browsing.",
+  "color": "#0891b2",
+  "author": "shortkeys",
+  "category": "accessibility",
+  "tags": ["accessibility", "a11y", "zoom", "navigation"],
+  "shortcuts": [
+    { "key": "alt+equal", "action": "zoomin", "label": "Zoom in" },
+    { "key": "alt+minus", "action": "zoomout", "label": "Zoom out" },
+    { "key": "alt+0", "action": "zoomreset", "label": "Reset zoom" },
+    { "key": "alt+home", "action": "top", "label": "Jump to top of page" },
+    { "key": "alt+end", "action": "bottom", "label": "Jump to bottom of page" },
+    { "key": "alt+p", "action": "print", "label": "Print page" },
+    { "key": "alt+shift+v", "action": "viewsource", "label": "View page source" }
+  ]
+}

--- a/community-packs/focus-mode.json
+++ b/community-packs/focus-mode.json
@@ -1,0 +1,18 @@
+{
+  "id": "community-focus-mode",
+  "name": "Focus Mode",
+  "icon": "🎯",
+  "description": "Minimize distractions while working. Close unneeded tabs, mute audio, and keep your workspace clean.",
+  "color": "#7c3aed",
+  "author": "shortkeys",
+  "category": "productivity",
+  "tags": ["focus", "productivity", "clean", "workspace"],
+  "shortcuts": [
+    { "key": "alt+shift+f", "action": "onlytab", "label": "Close all other tabs" },
+    { "key": "alt+shift+m", "action": "togglemute", "label": "Mute/unmute current tab" },
+    { "key": "alt+shift+d", "action": "discardtab", "label": "Suspend tab to free memory" },
+    { "key": "alt+shift+p", "action": "togglepin", "label": "Pin/unpin current tab" },
+    { "key": "alt+shift+b", "action": "togglebookmark", "label": "Bookmark current page" },
+    { "key": "alt+shift+s", "action": "sorttabs", "label": "Sort tabs alphabetically" }
+  ]
+}

--- a/community-packs/research.json
+++ b/community-packs/research.json
@@ -1,0 +1,19 @@
+{
+  "id": "community-research",
+  "name": "Research Workflow",
+  "icon": "🔬",
+  "description": "Speed up research with shortcuts for searching, copying references, and managing research tabs.",
+  "color": "#059669",
+  "author": "shortkeys",
+  "category": "productivity",
+  "tags": ["research", "academic", "search", "reference"],
+  "shortcuts": [
+    { "key": "alt+g", "action": "searchgoogle", "label": "Search Google for selection" },
+    { "key": "alt+w", "action": "searchwikipedia", "label": "Search Wikipedia for selection" },
+    { "key": "alt+shift+c", "action": "copytitleurlmarkdown", "label": "Copy as markdown link" },
+    { "key": "alt+shift+u", "action": "copyurl", "label": "Copy current URL" },
+    { "key": "alt+shift+t", "action": "copytitleurl", "label": "Copy title and URL" },
+    { "key": "alt+shift+n", "action": "newtabright", "label": "New tab to the right" },
+    { "key": "alt+shift+x", "action": "clonetab", "label": "Duplicate tab" }
+  ]
+}

--- a/community-packs/window-manager.json
+++ b/community-packs/window-manager.json
@@ -1,0 +1,19 @@
+{
+  "id": "community-window-manager",
+  "name": "Window Manager",
+  "icon": "🪟",
+  "description": "Quickly manage browser windows and move tabs between them. Perfect for multi-monitor setups.",
+  "color": "#d97706",
+  "author": "shortkeys",
+  "category": "productivity",
+  "tags": ["windows", "multi-monitor", "workspace", "organization"],
+  "shortcuts": [
+    { "key": "alt+shift+w", "action": "newwindow", "label": "New window" },
+    { "key": "alt+shift+i", "action": "newprivatewindow", "label": "New private window" },
+    { "key": "alt+shift+q", "action": "closewindow", "label": "Close window" },
+    { "key": "alt+shift+enter", "action": "fullscreen", "label": "Toggle fullscreen" },
+    { "key": "alt+shift+o", "action": "movetabtonewwindow", "label": "Move tab to new window" },
+    { "key": "alt+shift+g", "action": "grouptab", "label": "Add tab to group" },
+    { "key": "alt+shift+r", "action": "openincognito", "label": "Open in incognito" }
+  ]
+}

--- a/scripts/build-catalog.ts
+++ b/scripts/build-catalog.ts
@@ -1,14 +1,15 @@
 /**
- * Script to generate the community catalog.json from built-in packs.
+ * Script to generate catalog.json from built-in packs and community.json from community packs.
  * Run: npx tsx scripts/build-catalog.ts
  */
 import { ALL_PACKS } from '../src/packs/index.js'
-import { writeFileSync, mkdirSync } from 'fs'
+import { writeFileSync, mkdirSync, readdirSync, readFileSync } from 'fs'
 import { resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
+// --- Built-in packs catalog ---
 const catalog = {
   version: 1,
   updated: new Date().toISOString(),
@@ -32,3 +33,57 @@ const outDir = resolve(__dirname, '../site')
 mkdirSync(outDir, { recursive: true })
 writeFileSync(resolve(outDir, 'catalog.json'), JSON.stringify(catalog, null, 2))
 console.log(`Generated catalog.json with ${catalog.packs.length} packs`)
+
+// --- Community packs catalog ---
+const communityDir = resolve(__dirname, '../community-packs')
+const communityFiles = readdirSync(communityDir).filter((f) => f.endsWith('.json'))
+
+interface CommunityPackJson {
+  id: string
+  name: string
+  icon: string
+  description: string
+  color: string
+  author: string
+  category?: string
+  tags?: string[]
+  shortcuts: Array<{
+    key: string
+    action: string
+    label?: string
+    code?: string
+    [key: string]: unknown
+  }>
+}
+
+const communityPacks = communityFiles.map((file) => {
+  const raw = readFileSync(resolve(communityDir, file), 'utf-8')
+  const pack: CommunityPackJson = JSON.parse(raw)
+  return {
+    id: pack.id,
+    name: pack.name,
+    icon: pack.icon,
+    description: pack.description,
+    color: pack.color,
+    author: pack.author,
+    category: pack.category || 'uncategorized',
+    tags: pack.tags || [],
+    shortcutCount: pack.shortcuts.length,
+    hasJavaScript: pack.shortcuts.some((s) => s.action === 'javascript'),
+    shortcuts: pack.shortcuts.map((s) => ({
+      key: s.key,
+      action: s.action,
+      label: s.label || s.action,
+    })),
+    fullShortcuts: pack.shortcuts,
+  }
+})
+
+const communityCatalog = {
+  version: 1,
+  updated: new Date().toISOString(),
+  packs: communityPacks,
+}
+
+writeFileSync(resolve(outDir, 'community.json'), JSON.stringify(communityCatalog, null, 2))
+console.log(`Generated community.json with ${communityPacks.length} community packs`)

--- a/src/components/CommunityPackModal.vue
+++ b/src/components/CommunityPackModal.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+import { useCommunityPacks } from '@/composables/useCommunityPacks'
+
+const { 
+  previewCommunityPack, 
+  communityConflictMode, 
+  getCommunityPackConflicts, 
+  requestInstallCommunityPack 
+} = useCommunityPacks()
+</script>
+
+<template>
+  <Transition name="modal">
+    <div v-if="previewCommunityPack" class="modal-overlay" @click.self="previewCommunityPack = null">
+      <div class="modal-panel">
+        <div class="modal-header" :style="{ background: previewCommunityPack.color }">
+          <span class="modal-icon">{{ previewCommunityPack.icon }}</span>
+          <div>
+            <h2 class="modal-title">{{ previewCommunityPack.name }}</h2>
+            <p class="modal-subtitle">{{ previewCommunityPack.description }}</p>
+            <div class="modal-author-badge">
+              <i class="mdi mdi-account"></i> {{ previewCommunityPack.author }}
+              <span class="community-badge">Community</span>
+            </div>
+          </div>
+          <button class="modal-close" @click="previewCommunityPack = null" type="button">
+            <i class="mdi mdi-close"></i>
+          </button>
+        </div>
+        <div class="modal-body">
+          <div v-if="previewCommunityPack.hasJavaScript" class="modal-js-warning">
+            <i class="mdi mdi-alert-outline"></i>
+            This pack contains custom JavaScript. Only install if you trust the author.
+          </div>
+
+          <div class="modal-shortcuts">
+            <div v-for="s in previewCommunityPack.shortcuts" :key="s.key" class="modal-shortcut-row">
+              <span class="modal-shortcut-label">{{ s.label || s.action }}</span>
+              <span class="modal-shortcut-keys">
+                <kbd v-for="(part, pi) in s.key.split('+')" :key="pi">{{ part }}</kbd>
+              </span>
+            </div>
+          </div>
+
+          <div v-if="getCommunityPackConflicts(previewCommunityPack).length > 0" class="modal-conflicts">
+            <div class="modal-conflict-header">
+              <i class="mdi mdi-alert-outline"></i>
+              {{ getCommunityPackConflicts(previewCommunityPack).length }} shortcut{{ getCommunityPackConflicts(previewCommunityPack).length > 1 ? 's' : '' }} conflict with your existing shortcuts
+            </div>
+            <div class="modal-conflict-options">
+              <label class="radio-option">
+                <input type="radio" v-model="communityConflictMode" value="replace" />
+                <span>Replace my shortcuts with pack versions</span>
+              </label>
+              <label class="radio-option">
+                <input type="radio" v-model="communityConflictMode" value="skip" />
+                <span>Skip conflicting shortcuts</span>
+              </label>
+              <label class="radio-option">
+                <input type="radio" v-model="communityConflictMode" value="keep" />
+                <span>Keep both (I'll sort it out later)</span>
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-secondary" @click="previewCommunityPack = null" type="button">Cancel</button>
+          <button class="btn btn-primary" @click="requestInstallCommunityPack(previewCommunityPack)" type="button">
+            <i class="mdi mdi-plus"></i> Add {{ previewCommunityPack.shortcuts.length }} shortcuts
+          </button>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.modal-author-badge {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+  font-size: 12px;
+  opacity: 0.9;
+}
+.community-badge {
+  background: rgba(255, 255, 255, 0.2);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+}
+.modal-js-warning {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  color: #92400e;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  font-size: 13px;
+  font-weight: 500;
+}
+.modal-js-warning .mdi {
+  font-size: 16px;
+}
+</style>

--- a/src/components/ImportTab.vue
+++ b/src/components/ImportTab.vue
@@ -1,10 +1,27 @@
 <script setup lang="ts">
+import { onMounted } from 'vue'
 import { ALL_PACKS } from '@/packs'
 import { usePacks } from '@/composables/usePacks'
 import { useImportExport } from '@/composables/useImportExport'
+import { useCommunityPacks } from '@/composables/useCommunityPacks'
 
 const { previewPack } = usePacks()
 const { importJson, importKeys } = useImportExport()
+const {
+  communityLoading,
+  communityError,
+  communitySearchQuery,
+  communityCategory,
+  communityCategories,
+  filteredCommunityPacks,
+  previewCommunityPack,
+  fetchCommunityPacks,
+  requestInstallCommunityPack,
+} = useCommunityPacks()
+
+onMounted(() => {
+  fetchCommunityPacks()
+})
 </script>
 
 <template>
@@ -38,6 +55,90 @@ const { importJson, importKeys } = useImportExport()
 
     <div class="import-divider"></div>
 
+    <!-- Community Packs -->
+    <div class="import-section packs-section">
+      <div class="section-header">
+        <h3 class="section-title">Community packs</h3>
+        <p class="tab-desc">Shortcut packs created by the community. <a href="https://github.com/crittermike/shortkeys/tree/master/community-packs" target="_blank">Submit your own on GitHub.</a></p>
+      </div>
+
+      <!-- Loading -->
+      <div v-if="communityLoading" class="community-loading">
+        <i class="mdi mdi-loading mdi-spin"></i>
+        <span>Loading community packs…</span>
+      </div>
+
+      <!-- Error -->
+      <div v-else-if="communityError" class="community-error">
+        <i class="mdi mdi-alert-circle-outline"></i>
+        <span>{{ communityError }}</span>
+        <button class="btn btn-secondary btn-sm" @click="fetchCommunityPacks" type="button">
+          <i class="mdi mdi-refresh"></i> Retry
+        </button>
+      </div>
+
+      <!-- Loaded -->
+      <template v-else>
+        <!-- Filters -->
+        <div class="community-filters">
+          <div class="search-wrap">
+            <i class="mdi mdi-magnify search-icon"></i>
+            <input
+              class="search-input"
+              type="text"
+              placeholder="Search community packs…"
+              v-model="communitySearchQuery"
+            />
+            <button v-if="communitySearchQuery" class="search-clear" @click="communitySearchQuery = ''" type="button">
+              <i class="mdi mdi-close"></i>
+            </button>
+          </div>
+          <div v-if="communityCategories.length > 1" class="category-chips">
+            <button
+              :class="['category-chip', { active: communityCategory === 'all' }]"
+              @click="communityCategory = 'all'"
+              type="button"
+            >All</button>
+            <button
+              v-for="cat in communityCategories"
+              :key="cat"
+              :class="['category-chip', { active: communityCategory === cat }]"
+              @click="communityCategory = cat"
+              type="button"
+            >{{ cat }}</button>
+          </div>
+        </div>
+
+        <!-- Empty -->
+        <div v-if="filteredCommunityPacks.length === 0" class="community-empty">
+          <i class="mdi mdi-package-variant-closed"></i>
+          <span>No community packs found{{ communitySearchQuery ? ' matching your search' : '' }}</span>
+        </div>
+
+        <!-- Pack grid -->
+        <div v-else class="pack-grid">
+          <div v-for="pack in filteredCommunityPacks" :key="pack.id" class="pack-card" :style="{ borderTopColor: pack.color, '--pack-color': pack.color }">
+            <div class="pack-header">
+              <div class="pack-icon">{{ pack.icon }}</div>
+              <div class="pack-info">
+                <div class="pack-name">{{ pack.name }} <span class="community-badge">Community</span></div>
+                <div class="pack-meta">{{ pack.shortcutCount }} shortcuts</div>
+              </div>
+            </div>
+            <div class="pack-author"><i class="mdi mdi-account"></i> {{ pack.author }}</div>
+            <div class="pack-desc">{{ pack.description }}</div>
+            <div class="pack-actions">
+              <button class="btn btn-secondary btn-sm" @click="previewCommunityPack = pack" type="button">Preview</button>
+              <button class="btn btn-primary btn-sm" @click="requestInstallCommunityPack(pack)" type="button">
+                <i class="mdi mdi-plus"></i> Add
+              </button>
+            </div>
+          </div>
+        </div>
+      </template>
+    </div>
+
+
     <!-- JSON Import -->
     <div class="import-section json-section">
       <div class="section-header">
@@ -64,3 +165,80 @@ const { importJson, importKeys } = useImportExport()
     </div>
   </div>
 </template>
+
+<style scoped>
+.community-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+.category-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.category-chip {
+  padding: 6px 14px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.category-chip:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.category-chip.active {
+  background: var(--blue);
+  color: #fff;
+  border-color: var(--blue);
+}
+.community-loading, .community-error, .community-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--text-muted);
+  background: var(--bg-elevated);
+  border-radius: 12px;
+  border: 1px dashed var(--border);
+  gap: 12px;
+}
+.community-loading .mdi, .community-error .mdi, .community-empty .mdi {
+  font-size: 32px;
+  opacity: 0.5;
+}
+.community-error {
+  color: #ef4444;
+  background: #fef2f2;
+  border-color: #fecaca;
+}
+.pack-author {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: -6px;
+}
+.community-badge {
+  background: var(--bg-hover);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+.community-filters .search-wrap {
+  max-width: 400px;
+}
+</style>

--- a/src/components/JsWarningDialog.vue
+++ b/src/components/JsWarningDialog.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useCommunityPacks } from '@/composables/useCommunityPacks'
+
+const { jsWarningPack, confirmJsInstall, dismissJsWarning } = useCommunityPacks()
+
+const jsShortcutCount = computed(() => {
+  if (!jsWarningPack.value) return 0
+  return jsWarningPack.value.fullShortcuts.filter(s => s.action === 'javascript').length
+})
+</script>
+
+<template>
+  <Transition name="modal">
+    <div v-if="jsWarningPack" class="modal-overlay" @click.self="dismissJsWarning">
+      <div class="modal-panel warning-panel">
+        <div class="modal-header warning-header">
+          <span class="modal-icon"><i class="mdi mdi-alert"></i></span>
+          <div>
+            <h2 class="modal-title">Security Warning</h2>
+            <p class="modal-subtitle">Custom JavaScript detected</p>
+          </div>
+          <button class="modal-close" @click="dismissJsWarning" type="button">
+            <i class="mdi mdi-close"></i>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p class="warning-text">
+            This community pack (<strong>{{ jsWarningPack.name }}</strong> by {{ jsWarningPack.author }}) contains <strong>{{ jsShortcutCount }} custom JavaScript shortcut{{ jsShortcutCount !== 1 ? 's' : '' }}</strong> that will run on web pages you visit.
+          </p>
+          <p class="warning-text">
+            Only install packs from authors you trust. Malicious code could potentially access your personal data on websites.
+          </p>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-secondary" @click="dismissJsWarning" type="button">Cancel</button>
+          <button class="btn btn-warning" @click="confirmJsInstall" type="button">
+            Install anyway
+          </button>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.warning-panel {
+  max-width: 480px;
+}
+.warning-header {
+  background: #f59e0b;
+}
+.warning-text {
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0 0 12px;
+  color: var(--text);
+}
+.warning-text:last-child {
+  margin-bottom: 0;
+}
+.btn-warning {
+  background: #ef4444;
+  color: #fff;
+}
+.btn-warning:hover {
+  background: #dc2626;
+}
+</style>

--- a/src/composables/useCommunityPacks.ts
+++ b/src/composables/useCommunityPacks.ts
@@ -1,0 +1,165 @@
+import { ref, computed } from 'vue'
+import { v4 as uuid } from 'uuid'
+import type { KeySetting } from '@/utils/url-matching'
+import { useShortcuts } from './useShortcuts'
+import { useToast } from './useToast'
+
+export interface CommunityPack {
+  id: string
+  name: string
+  icon: string
+  description: string
+  color: string
+  author: string
+  category: string
+  tags: string[]
+  shortcutCount: number
+  hasJavaScript: boolean
+  shortcuts: Array<{ key: string; action: string; label: string }>
+  fullShortcuts: KeySetting[]
+}
+
+interface CommunityCatalog {
+  version: number
+  updated: string
+  packs: CommunityPack[]
+}
+
+// Module-level state so all callers share the same refs
+const communityPacks = ref<CommunityPack[]>([])
+const communityLoading = ref(false)
+const communityError = ref<string | null>(null)
+const communitySearchQuery = ref('')
+const communityCategory = ref<string>('all')
+const previewCommunityPack = ref<CommunityPack | null>(null)
+const communityConflictMode = ref<'skip' | 'replace' | 'keep'>('replace')
+const jsWarningPack = ref<CommunityPack | null>(null)
+
+const COMMUNITY_CATALOG_URL = 'https://shortkeys.app/community.json'
+
+export function useCommunityPacks() {
+  const { keys, saveShortcuts } = useShortcuts()
+  const { showSnack } = useToast()
+
+  /** Unique category values from loaded community packs */
+  const communityCategories = computed(() => {
+    const cats = new Set<string>()
+    for (const p of communityPacks.value) {
+      if (p.category) cats.add(p.category)
+    }
+    return Array.from(cats).sort()
+  })
+
+  /** Filter community packs by search query and category */
+  const filteredCommunityPacks = computed(() => {
+    let packs = communityPacks.value
+    if (communityCategory.value !== 'all') {
+      packs = packs.filter((p) => p.category === communityCategory.value)
+    }
+    const q = communitySearchQuery.value.toLowerCase().trim()
+    if (q) {
+      packs = packs.filter(
+        (p) =>
+          p.name.toLowerCase().includes(q) ||
+          p.description.toLowerCase().includes(q) ||
+          p.author.toLowerCase().includes(q) ||
+          p.tags.some((t) => t.toLowerCase().includes(q)),
+      )
+    }
+    return packs
+  })
+
+  /** Fetch community packs from the catalog */
+  async function fetchCommunityPacks() {
+    if (communityPacks.value.length > 0 && !communityError.value) return // Already loaded
+    communityLoading.value = true
+    communityError.value = null
+    try {
+      const resp = await fetch(COMMUNITY_CATALOG_URL)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data: CommunityCatalog = await resp.json()
+      communityPacks.value = data.packs
+    } catch (e) {
+      communityError.value = 'Failed to load community packs. Check your internet connection.'
+      console.error('Failed to fetch community packs:', e)
+    } finally {
+      communityLoading.value = false
+    }
+  }
+
+  /** Get conflicts between a community pack and existing shortcuts */
+  function getCommunityPackConflicts(pack: CommunityPack): string[] {
+    const existing = new Set(keys.value.map((k) => k.key?.toLowerCase()).filter(Boolean))
+    return pack.fullShortcuts.filter((s) => existing.has(s.key?.toLowerCase())).map((s) => s.key)
+  }
+
+  /** Try to install a community pack. If it has JS, shows the warning first. */
+  function requestInstallCommunityPack(pack: CommunityPack) {
+    if (pack.hasJavaScript) {
+      jsWarningPack.value = pack
+    } else {
+      installCommunityPack(pack)
+    }
+  }
+
+  /** Actually install a community pack */
+  async function installCommunityPack(pack: CommunityPack) {
+    const mode = communityConflictMode.value
+    const groupName = pack.name
+    const existingKeys = new Set(keys.value.map((k) => k.key?.toLowerCase()).filter(Boolean))
+
+    const newShortcuts = pack.fullShortcuts.map((s) => ({
+      ...s,
+      id: uuid(),
+      group: groupName,
+      enabled: true,
+    }))
+
+    if (mode === 'skip') {
+      const toAdd = newShortcuts.filter((s) => !existingKeys.has(s.key?.toLowerCase()))
+      keys.value.push(...toAdd)
+    } else if (mode === 'replace') {
+      const packKeys = new Set(newShortcuts.map((s) => s.key?.toLowerCase()))
+      keys.value = keys.value.filter((k) => !packKeys.has(k.key?.toLowerCase()))
+      keys.value.push(...newShortcuts)
+    } else {
+      keys.value.push(...newShortcuts)
+    }
+
+    previewCommunityPack.value = null
+    jsWarningPack.value = null
+    await saveShortcuts()
+    showSnack(`✓ Added "${pack.name}" (${newShortcuts.length} shortcuts)`)
+  }
+
+  /** Confirm JS warning and proceed with install */
+  function confirmJsInstall() {
+    if (jsWarningPack.value) {
+      installCommunityPack(jsWarningPack.value)
+    }
+  }
+
+  /** Dismiss JS warning */
+  function dismissJsWarning() {
+    jsWarningPack.value = null
+  }
+
+  return {
+    communityPacks,
+    communityLoading,
+    communityError,
+    communitySearchQuery,
+    communityCategory,
+    communityCategories,
+    filteredCommunityPacks,
+    previewCommunityPack,
+    communityConflictMode,
+    jsWarningPack,
+    fetchCommunityPacks,
+    getCommunityPackConflicts,
+    requestInstallCommunityPack,
+    installCommunityPack,
+    confirmJsInstall,
+    dismissJsWarning,
+  }
+}

--- a/src/composables/useImportExport.ts
+++ b/src/composables/useImportExport.ts
@@ -54,5 +54,38 @@ export function useImportExport() {
     }
   }
 
-  return { importJson, shareLink, importKeys, copyExport, generateShareLink, shareGroup }
+  function publishToCommunity(group: string) {
+    const groupShortcuts = keys.value.filter((k) => (k.group || DEFAULT_GROUP) === group)
+    if (groupShortcuts.length === 0) {
+      showSnack('No shortcuts in this group to publish.', 'danger')
+      return
+    }
+
+    const packData = {
+      id: `community-${group.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
+      name: group,
+      icon: '📦',
+      description: '',
+      color: '#4361ee',
+      author: '',
+      category: 'uncategorized',
+      tags: [],
+      shortcuts: groupShortcuts.map((s) => ({
+        key: s.key,
+        action: s.action,
+        label: s.label || s.action,
+        ...(s.code ? { code: s.code } : {}),
+      })),
+    }
+
+    const json = JSON.stringify(packData, null, 2)
+    const fileName = `${packData.id}.json`
+    const title = encodeURIComponent(`Community pack: ${group}`)
+    const body = encodeURIComponent(`## New community pack submission\n\n**Pack name:** ${group}\n**File name:** \`community-packs/${fileName}\`\n\n### Pack JSON\n\n\`\`\`json\n${json}\n\`\`\`\n\nPlease fill in the \`description\`, \`author\`, \`icon\`, \`color\`, \`category\`, and \`tags\` fields before submitting.`)
+    const url = `https://github.com/crittermike/shortkeys/issues/new?title=${title}&body=${body}&labels=community-pack`
+    window.open(url, '_blank')
+    showSnack('GitHub issue opened — fill in the details and submit!')
+  }
+
+  return { importJson, shareLink, importKeys, copyExport, generateShareLink, shareGroup, publishToCommunity }
 }

--- a/src/entrypoints/options/App.vue
+++ b/src/entrypoints/options/App.vue
@@ -6,6 +6,8 @@ import ShortcutRecorder from '@/components/ShortcutRecorder.vue'
 import ShortcutDetails from '@/components/ShortcutDetails.vue'
 import ImportTab from '@/components/ImportTab.vue'
 import PackPreviewModal from '@/components/PackPreviewModal.vue'
+import CommunityPackModal from '@/components/CommunityPackModal.vue'
+import JsWarningDialog from '@/components/JsWarningDialog.vue'
 import ExportTab from '@/components/ExportTab.vue'
 import AnalyticsTab from '@/components/AnalyticsTab.vue'
 import { useTheme } from '@/composables/useTheme'
@@ -40,7 +42,7 @@ const {
 } = useGroups()
 const { convertToMacro } = useMacros()
 const { dragIndex, onDragStart, onDragOver, onDragOverGroup, onDragEnd } = useDragDrop()
-const { shareGroup } = useImportExport()
+const { shareGroup, publishToCommunity } = useImportExport()
 const { refreshTabs, loadBookmarks } = useJsTools()
 
 // --- Lifecycle ---
@@ -200,6 +202,9 @@ onMounted(async () => {
                     <button class="group-menu-item" @click="shareGroup(group)">
                       <i class="mdi mdi-share-variant-outline"></i> Share group
                     </button>
+                    <button class="group-menu-item" @click="publishToCommunity(group)">
+                      <i class="mdi mdi-upload-outline"></i> Publish to community
+                    </button>
                     <button class="group-menu-item group-menu-danger" @click="deleteGroup(group)">
                       <i class="mdi mdi-delete-outline"></i> Delete group
                     </button>
@@ -351,6 +356,8 @@ onMounted(async () => {
 
       <!-- Pack Preview Modal -->
       <PackPreviewModal />
+      <CommunityPackModal />
+      <JsWarningDialog />
 
       <!-- Export Tab -->
       <div v-show="activeTab === 2" class="tab-content">

--- a/tests/community-packs.test.ts
+++ b/tests/community-packs.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { getAllActionValues } from '../src/utils/actions-registry'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const communityDir = resolve(__dirname, '../community-packs')
+
+interface CommunityPackJson {
+  id: string
+  name: string
+  icon: string
+  description: string
+  color: string
+  author: string
+  category?: string
+  tags?: string[]
+  shortcuts: Array<{
+    key: string
+    action: string
+    label?: string
+    code?: string
+  }>
+}
+
+function loadCommunityPacks(): CommunityPackJson[] {
+  const files = readdirSync(communityDir).filter((f) => f.endsWith('.json'))
+  return files.map((file) => {
+    const raw = readFileSync(resolve(communityDir, file), 'utf-8')
+    return JSON.parse(raw) as CommunityPackJson
+  })
+}
+
+const VALID_CATEGORIES = [
+  'productivity',
+  'navigation',
+  'accessibility',
+  'developer',
+  'media',
+  'reading',
+  'uncategorized',
+]
+
+describe('community pack JSON validation', () => {
+  const packs = loadCommunityPacks()
+
+  it('has at least one community pack', () => {
+    expect(packs.length).toBeGreaterThan(0)
+  })
+
+  it('all packs have required metadata fields', () => {
+    for (const pack of packs) {
+      expect(pack.id, `Pack missing id`).toBeTruthy()
+      expect(pack.name, `${pack.id} missing name`).toBeTruthy()
+      expect(pack.icon, `${pack.id} missing icon`).toBeTruthy()
+      expect(pack.description, `${pack.id} missing description`).toBeTruthy()
+      expect(pack.color, `${pack.id} missing color`).toBeTruthy()
+      expect(pack.author, `${pack.id} missing author`).toBeTruthy()
+      expect(pack.shortcuts, `${pack.id} missing shortcuts`).toBeDefined()
+      expect(pack.shortcuts.length, `${pack.id} has no shortcuts`).toBeGreaterThan(0)
+    }
+  })
+
+  it('all pack IDs start with "community-"', () => {
+    for (const pack of packs) {
+      expect(pack.id, `${pack.id} must start with "community-"`).toMatch(/^community-/)
+    }
+  })
+
+  it('all pack IDs are unique', () => {
+    const ids = packs.map((p) => p.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('all pack colors are valid hex colors', () => {
+    for (const pack of packs) {
+      expect(pack.color, `${pack.id} has invalid color "${pack.color}"`).toMatch(/^#[0-9a-fA-F]{6}$/)
+    }
+  })
+
+  it('all pack categories are valid', () => {
+    for (const pack of packs) {
+      const category = pack.category || 'uncategorized'
+      expect(
+        VALID_CATEGORIES,
+        `${pack.id} has invalid category "${category}"`,
+      ).toContain(category)
+    }
+  })
+
+  it('all pack shortcuts have valid action names', () => {
+    const validActions = getAllActionValues()
+    const specialActions = ['lastusedtab']
+
+    for (const pack of packs) {
+      for (const s of pack.shortcuts) {
+        const allValid = [...validActions, ...specialActions]
+        expect(
+          allValid,
+          `Community pack "${pack.name}": unknown action "${s.action}" on key "${s.key}"`,
+        ).toContain(s.action)
+      }
+    }
+  })
+
+  it('all pack shortcuts have a key binding', () => {
+    for (const pack of packs) {
+      for (const s of pack.shortcuts) {
+        expect(s.key, `Pack "${pack.name}": shortcut with action "${s.action}" has no key`).toBeTruthy()
+      }
+    }
+  })
+
+  it('all pack shortcuts have a label', () => {
+    for (const pack of packs) {
+      for (const s of pack.shortcuts) {
+        expect(s.label, `Pack "${pack.name}": key "${s.key}" has no label`).toBeTruthy()
+      }
+    }
+  })
+
+  it('labels use sentence case', () => {
+    for (const pack of packs) {
+      for (const s of pack.shortcuts) {
+        if (!s.label) continue
+        // First word is capitalized, subsequent words should not all be capitalized
+        // (unless they are proper nouns, but we just check the pattern)
+        const words = s.label.split(' ')
+        if (words.length > 1) {
+          // At least some non-first words should be lowercase
+          const nonFirstWords = words.slice(1).filter((w) => w.length > 2) // skip short words
+          const allCaps = nonFirstWords.every((w) => w[0] === w[0].toUpperCase())
+          if (allCaps && nonFirstWords.length > 2) {
+            throw new Error(
+              `Pack "${pack.name}": label "${s.label}" should use sentence case`,
+            )
+          }
+        }
+      }
+    }
+  })
+
+  it('no duplicate keys within a single pack', () => {
+    for (const pack of packs) {
+      const keys = pack.shortcuts.map((s) => s.key.toLowerCase())
+      const unique = new Set(keys)
+      expect(unique.size, `Pack "${pack.name}" has duplicate keys`).toBe(keys.length)
+    }
+  })
+
+  it('tags is an array when present', () => {
+    for (const pack of packs) {
+      if (pack.tags !== undefined) {
+        expect(Array.isArray(pack.tags), `${pack.id} tags must be an array`).toBe(true)
+      }
+    }
+  })
+
+  it('javascript actions include code field', () => {
+    for (const pack of packs) {
+      for (const s of pack.shortcuts) {
+        if (s.action === 'javascript') {
+          expect(s.code, `Pack "${pack.name}": javascript action on key "${s.key}" missing code field`).toBeTruthy()
+        }
+      }
+    }
+  })
+})
+
+describe('community pack build script', () => {
+  it('generates valid community.json from pack files', () => {
+    const files = readdirSync(communityDir).filter((f) => f.endsWith('.json'))
+    const packs = files.map((file) => {
+      const raw = readFileSync(resolve(communityDir, file), 'utf-8')
+      const pack: CommunityPackJson = JSON.parse(raw)
+      return {
+        id: pack.id,
+        name: pack.name,
+        icon: pack.icon,
+        description: pack.description,
+        color: pack.color,
+        author: pack.author,
+        category: pack.category || 'uncategorized',
+        tags: pack.tags || [],
+        shortcutCount: pack.shortcuts.length,
+        hasJavaScript: pack.shortcuts.some((s) => s.action === 'javascript'),
+        shortcuts: pack.shortcuts.map((s) => ({
+          key: s.key,
+          action: s.action,
+          label: s.label || s.action,
+        })),
+        fullShortcuts: pack.shortcuts,
+      }
+    })
+
+    const catalog = {
+      version: 1,
+      updated: new Date().toISOString(),
+      packs,
+    }
+
+    // Validate catalog structure
+    expect(catalog.version).toBe(1)
+    expect(catalog.updated).toBeTruthy()
+    expect(catalog.packs.length).toBe(files.length)
+
+    for (const pack of catalog.packs) {
+      expect(pack.id).toBeTruthy()
+      expect(pack.name).toBeTruthy()
+      expect(pack.shortcutCount).toBeGreaterThan(0)
+      expect(typeof pack.hasJavaScript).toBe('boolean')
+      expect(Array.isArray(pack.shortcuts)).toBe(true)
+      expect(Array.isArray(pack.fullShortcuts)).toBe(true)
+      expect(pack.shortcuts.length).toBe(pack.shortcutCount)
+      expect(pack.fullShortcuts.length).toBe(pack.shortcutCount)
+    }
+  })
+
+  it('community pack shortcutCount matches actual shortcuts', () => {
+    const packs = loadCommunityPacks()
+    for (const pack of packs) {
+      const generated = {
+        shortcutCount: pack.shortcuts.length,
+        shortcuts: pack.shortcuts,
+      }
+      expect(generated.shortcutCount).toBe(generated.shortcuts.length)
+    }
+  })
+
+  it('hasJavaScript is set correctly', () => {
+    const packs = loadCommunityPacks()
+    for (const pack of packs) {
+      const hasJs = pack.shortcuts.some((s) => s.action === 'javascript')
+      const generated = {
+        hasJavaScript: pack.shortcuts.some((s) => s.action === 'javascript'),
+      }
+      expect(generated.hasJavaScript).toBe(hasJs)
+    }
+  })
+})
+
+describe('community pack install modes', () => {
+  function simulateInstall(
+    existing: Array<{ key: string; action: string }>,
+    packShortcuts: Array<{ key: string; action: string; label: string }>,
+    packName: string,
+    mode: 'skip' | 'replace' | 'keep',
+  ) {
+    const existingKeys = new Set(existing.map((k) => k.key.toLowerCase()))
+    const newShortcuts = packShortcuts.map((s) => ({ ...s, group: packName }))
+    let result = [...existing]
+
+    if (mode === 'skip') {
+      const toAdd = newShortcuts.filter((s) => !existingKeys.has(s.key.toLowerCase()))
+      result.push(...toAdd)
+    } else if (mode === 'replace') {
+      const packKeys = new Set(newShortcuts.map((s) => s.key.toLowerCase()))
+      result = result.filter((k) => !packKeys.has(k.key.toLowerCase()))
+      result.push(...newShortcuts)
+    } else {
+      result.push(...newShortcuts)
+    }
+
+    return result
+  }
+
+  const testPack = {
+    name: 'Test Pack',
+    shortcuts: [
+      { key: 'alt+shift+f', action: 'onlytab', label: 'Close all other tabs' },
+      { key: 'alt+shift+m', action: 'togglemute', label: 'Mute/unmute current tab' },
+    ],
+  }
+
+  it('skip mode preserves existing and only adds non-conflicting', () => {
+    const existing = [{ key: 'alt+shift+f', action: 'newtab' }]
+    const result = simulateInstall(existing, testPack.shortcuts, testPack.name, 'skip')
+    // Original preserved
+    expect(result.filter((s) => s.key === 'alt+shift+f')).toHaveLength(1)
+    expect(result.find((s) => s.key === 'alt+shift+f')!.action).toBe('newtab')
+    // Non-conflicting added
+    expect(result.find((s) => s.key === 'alt+shift+m')).toBeTruthy()
+    expect(result).toHaveLength(2)
+  })
+
+  it('replace mode removes conflicting and adds all from pack', () => {
+    const existing = [
+      { key: 'alt+shift+f', action: 'newtab' },
+      { key: 'ctrl+z', action: 'reload' },
+    ]
+    const result = simulateInstall(existing, testPack.shortcuts, testPack.name, 'replace')
+    // Pack's version replaces existing
+    const fEntries = result.filter((s) => s.key === 'alt+shift+f')
+    expect(fEntries).toHaveLength(1)
+    expect(fEntries[0].action).toBe('onlytab')
+    // Non-conflicting existing preserved
+    expect(result.find((s) => s.key === 'ctrl+z')).toBeTruthy()
+  })
+
+  it('keep mode adds all pack shortcuts alongside existing', () => {
+    const existing = [{ key: 'alt+shift+f', action: 'newtab' }]
+    const result = simulateInstall(existing, testPack.shortcuts, testPack.name, 'keep')
+    // Both entries exist
+    expect(result.filter((s) => s.key === 'alt+shift+f')).toHaveLength(2)
+    expect(result).toHaveLength(3)
+  })
+
+  it('installs with correct group name', () => {
+    const existing: Array<{ key: string; action: string }> = []
+    const result = simulateInstall(existing, testPack.shortcuts, testPack.name, 'replace')
+    for (const s of result) {
+      expect((s as any).group).toBe('Test Pack')
+    }
+  })
+})
+
+describe('community pack conflict detection', () => {
+  it('detects conflicts between community pack and existing shortcuts', () => {
+    const existingKeys = new Set(['alt+shift+f', 'alt+shift+m'])
+    const packs = loadCommunityPacks()
+    const focusPack = packs.find((p) => p.id === 'community-focus-mode')!
+    const conflicts = focusPack.shortcuts.filter((s) => existingKeys.has(s.key.toLowerCase()))
+    expect(conflicts.length).toBeGreaterThan(0)
+  })
+
+  it('reports no conflicts when no overlap', () => {
+    const existingKeys = new Set(['ctrl+shift+alt+z'])
+    const packs = loadCommunityPacks()
+    for (const pack of packs) {
+      const conflicts = pack.shortcuts.filter((s) => existingKeys.has(s.key.toLowerCase()))
+      expect(conflicts, `Pack "${pack.name}" should have no conflicts`).toHaveLength(0)
+    }
+  })
+})
+
+describe('community pack JS warning', () => {
+  it('packs without javascript actions do not require JS warning', () => {
+    const packs = loadCommunityPacks()
+    for (const pack of packs) {
+      const hasJs = pack.shortcuts.some((s) => s.action === 'javascript')
+      if (!hasJs) {
+        // No JS warning needed
+        expect(hasJs).toBe(false)
+      }
+    }
+  })
+
+  it('correctly identifies packs with javascript actions', () => {
+    // Create a mock pack with JS
+    const jsPack = {
+      shortcuts: [
+        { key: 'alt+j', action: 'javascript', label: 'Run script', code: 'alert("hi")' },
+        { key: 'alt+k', action: 'newtab', label: 'New tab' },
+      ],
+    }
+    const hasJs = jsPack.shortcuts.some((s) => s.action === 'javascript')
+    expect(hasJs).toBe(true)
+
+    // And one without
+    const noJsPack = {
+      shortcuts: [
+        { key: 'alt+k', action: 'newtab', label: 'New tab' },
+      ],
+    }
+    const noJs = noJsPack.shortcuts.some((s) => s.action === 'javascript')
+    expect(noJs).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Implements a community pack marketplace in the Import tab where users can discover, preview, and install shortcut packs created by the community. Closes #702.

## What's included

### UI
- **Community packs section** on the Import tab with search bar and category filter chips
- **Pack card grid** showing pack name, icon, author, description, shortcut count, and "Community" badge
- **Preview modal** to inspect pack contents before installing, with conflict detection and resolution options (skip/replace/keep)
- **JS warning dialog** shown before installing packs that contain JavaScript actions
- Loading, error, and empty states

### Backend
- **`useCommunityPacks` composable** — fetches catalog from `shortkeys.app/community.json`, provides search/filter/install logic
- **`publishToCommunity` function** — generates a pre-filled GitHub issue from a shortcut group for easy pack submissions
- **"Publish to community" group menu item** — right-click any group to submit it as a community pack
- **Build script** extended to generate `community.json` from `community-packs/` directory

### Content
- **4 seed community packs**: Focus Mode, Accessibility, Research Workflow, Window Manager
- **Contributing guide** (`community-packs/README.md`) with format spec and guidelines
- **GitHub issue template** for community pack submissions

### Tests
- **24 new tests** covering JSON validation, required fields, valid actions, install modes (skip/replace/keep), conflict detection, JS warning flow

## How it works
1. Community packs are JSON files in `community-packs/`
2. `npm run build:site` generates `community.json` (served from shortkeys.app)
3. The Import tab fetches the catalog and displays browsable pack cards
4. Users can submit packs via the "Publish to community" group menu or the GitHub issue template

## Notes
- Community packs won't load in dev mode since they fetch from the production URL — this is by design
- The 4 seed packs use only built-in actions (no JavaScript) so no JS warning is triggered
- All 532 tests pass (including 24 new community pack tests)