### PR TITLE
fix: resolve stale sync data causing imports to not persist (#710)

### DIFF
--- a/src/composables/useCommunityPacks.ts
+++ b/src/composables/useCommunityPacks.ts
@@ -109,8 +109,12 @@ export function useCommunityPacks() {
 
     previewCommunityPack.value = null
     jsWarningPack.value = null
-    await saveShortcuts()
-    showSnack(`✓ Added "${pack.name}" (${newShortcuts.length} shortcuts)`)
+    try {
+      await saveShortcuts()
+      showSnack(`Added "${pack.name}" (${newShortcuts.length} shortcuts)`)
+    } catch {
+      showSnack('Failed to save shortcuts. Please try again.', 'danger')
+    }
   }
 
   /** Confirm JS warning and proceed with install */

--- a/src/composables/useImportExport.ts
+++ b/src/composables/useImportExport.ts
@@ -13,9 +13,16 @@ export function useImportExport() {
   const shareLink = ref('')
 
   async function importKeys() {
+    let parsed: any
+    try {
+      parsed = JSON.parse(importJson.value)
+    } catch {
+      showSnack('Invalid JSON. Please check and try again.', 'danger')
+      return
+    }
+
     try {
       const { pushUndo } = useUndoRedo()
-      const parsed = JSON.parse(importJson.value)
       // Filter out empty/invalid shortcuts (#472/#598)
       const valid = (Array.isArray(parsed) ? parsed : [parsed]).filter(
         (k: any) => k && (k.key || k.action),
@@ -26,7 +33,7 @@ export function useImportExport() {
       await saveShortcuts()
       showSnack('Imported successfully!')
     } catch {
-      showSnack('Invalid JSON. Please check and try again.', 'danger')
+      showSnack('Failed to save shortcuts. Please try again.', 'danger')
     }
   }
 

--- a/src/composables/usePacks.ts
+++ b/src/composables/usePacks.ts
@@ -44,8 +44,12 @@ export function usePacks() {
     }
 
     previewPack.value = null
-    await saveShortcuts()
-    showSnack(`✓ Added "${pack.name}" (${newShortcuts.length} shortcuts)`)
+    try {
+      await saveShortcuts()
+      showSnack(`Added "${pack.name}" (${newShortcuts.length} shortcuts)`)
+    } catch {
+      showSnack('Failed to save shortcuts. Please try again.', 'danger')
+    }
   }
 
   return { previewPack, packConflictMode, getPackConflicts, installPack }

--- a/tests/autosave-import.test.ts
+++ b/tests/autosave-import.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockSyncGet = vi.fn()
 const mockSyncSet = vi.fn()
+const mockSyncRemove = vi.fn()
 const mockLocalGet = vi.fn()
 const mockLocalSet = vi.fn()
 const mockOnChanged = vi.fn()
@@ -10,7 +11,7 @@ const mockWriteText = vi.fn().mockResolvedValue(undefined)
 // @ts-ignore
 globalThis.chrome = {
   storage: {
-    sync: { get: mockSyncGet, set: mockSyncSet },
+    sync: { get: mockSyncGet, set: mockSyncSet, remove: mockSyncRemove },
     local: { get: mockLocalGet, set: mockLocalSet },
     onChanged: { addListener: mockOnChanged },
   },
@@ -32,6 +33,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   mockSyncGet.mockResolvedValue({})
   mockSyncSet.mockResolvedValue(undefined)
+  mockSyncRemove.mockResolvedValue(undefined)
   mockLocalGet.mockResolvedValue({})
   mockLocalSet.mockResolvedValue(undefined)
 })


### PR DESCRIPTION
## Summary

Fixes #710 and #741 -- imported shortcuts (and installed packs) appear in the UI but vanish on page reload for users whose data exceeds the 100KB sync storage quota.

## Root Cause

When `saveKeys()` falls back from `chrome.storage.sync` to `chrome.storage.local` (quota exceeded), it leaves stale data in sync storage. On the next page load, `loadKeys()` reads sync first and finds the old (smaller) dataset, ignoring the newer local data that contains the imported shortcuts.

## Changes

**`src/utils/storage.ts`**
- `saveKeys()`: When falling back to local-only, now calls `chrome.storage.sync.remove('keys')` to clear stale sync data
- `loadKeys()`: When both sync and local data exist, compares them and prefers whichever has more shortcuts (belt-and-suspenders defense against stale data)
- Removed dead `getStorage()` function

**`src/composables/useImportExport.ts`**
- Separated JSON parse errors from save errors -- users now see "Failed to save shortcuts" instead of misleading "Invalid JSON" when save fails

**`src/composables/usePacks.ts`**
- Added try/catch around `saveShortcuts()` in `installPack()` with error toast

**`src/composables/useCommunityPacks.ts`**
- Added try/catch around `saveShortcuts()` in `installCommunityPack()` with error toast

**Tests**
- 6 new tests for stale sync cleanup and loadKeys comparison logic
- Updated mock setup in autosave-import tests
- All 571 tests pass