### PR TITLE
fix: make clipboardRead an optional permission to prevent disable on upgrade

### DIFF
--- a/src/actions/action-handlers.ts
+++ b/src/actions/action-handlers.ts
@@ -272,6 +272,11 @@ const actionHandlers: Record<string, ActionHandler> = {
   },
 
   openclipboardurl: async () => {
+    const granted = await browser.permissions.request({ permissions: ['clipboardRead'] })
+    if (!granted) {
+      showPageToast('Clipboard permission is required for this action')
+      return true
+    }
     const results = await executeScript(() => navigator.clipboard.readText())
     const url = results?.[0]?.result?.trim()
     if (url) {
@@ -282,6 +287,11 @@ const actionHandlers: Record<string, ActionHandler> = {
   },
 
   openclipboardurlnewtab: async () => {
+    const granted = await browser.permissions.request({ permissions: ['clipboardRead'] })
+    if (!granted) {
+      showPageToast('Clipboard permission is required for this action')
+      return true
+    }
     const results = await executeScript(() => navigator.clipboard.readText())
     const url = results?.[0]?.result?.trim()
     if (url) {

--- a/tests/action-handlers.test.ts
+++ b/tests/action-handlers.test.ts
@@ -62,6 +62,7 @@ const browserMock = {
   management: { launchApp: mockManagementLaunchApp },
   scripting: { executeScript: vi.fn() },
   debugger: { attach: vi.fn(), detach: vi.fn(), sendCommand: vi.fn() },
+  permissions: { request: vi.fn().mockResolvedValue(true) },
 }
 
 // @ts-ignore

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -126,7 +126,6 @@ export default defineConfig({
       'storage',
       'tabs',
       'clipboardWrite',
-      'clipboardRead',
       'browsingData',
       'bookmarks',
       'sessions',
@@ -137,6 +136,7 @@ export default defineConfig({
       'activeTab',
       'userScripts',
     ],
+    optional_permissions: ['clipboardRead'],
     host_permissions: ['*://*/*'],
     externally_connectable: {
       matches: ['https://shortkeys.app/*', 'http://localhost/*'],


### PR DESCRIPTION
## Summary

- Moves `clipboardRead` from required `permissions` to `optional_permissions` in the manifest so that upgrading from v4→v5 doesn't trigger Chrome's new-permission disable behavior (#747)
- Requests `clipboardRead` at runtime via `browser.permissions.request()` when the user triggers `openclipboardurl` or `openclipboardurlnewtab`, with a toast message if denied
- Adds `permissions.request` mock to test setup

Fixes #747