### PR TITLE
feat: warn users about unsaved changes before closing options tab

### DIFF
--- a/src/entrypoints/options/App.vue
+++ b/src/entrypoints/options/App.vue
@@ -28,7 +28,7 @@ import { useViewDensity } from '@/composables/useViewDensity'
 const { darkMode, initTheme, toggleTheme } = useTheme()
 const { snackMessage, snackType, snackAction, dismissSnack } = useToast()
 const {
-  keys, expandedRow,
+  keys, expandedRow, dirty,
   addShortcut, saveShortcuts, deleteShortcut, toggleDetails,
   onActionChange, toggleEnabled, needsUserScripts, loadSavedKeys,
 } = useShortcuts()
@@ -86,6 +86,11 @@ function handleKeydown(e: KeyboardEvent) {
     redo()
   }
 }
+function handleBeforeUnload(e: BeforeUnloadEvent) {
+  if (dirty.value) {
+    e.preventDefault()
+  }
+}
 
 onMounted(async () => {
   await loadSavedKeys()
@@ -93,6 +98,7 @@ onMounted(async () => {
   refreshTabs()
   document.addEventListener('click', () => { groupMenuOpen.value = null })
   document.addEventListener('keydown', handleKeydown)
+  window.addEventListener('beforeunload', handleBeforeUnload)
   loadBookmarks()
   
   if (localStorage.getItem('shortkeys-onboarding-done') !== 'true') {
@@ -102,6 +108,7 @@ onMounted(async () => {
 
 onUnmounted(() => {
   document.removeEventListener('keydown', handleKeydown)
+  window.removeEventListener('beforeunload', handleBeforeUnload)
 })
 </script>
 

--- a/tests/dirty-tracking.test.ts
+++ b/tests/dirty-tracking.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { nextTick } from 'vue'
+
+vi.mock('@/utils/storage', () => ({
+  saveKeys: vi.fn().mockResolvedValue('sync'),
+  loadKeys: vi.fn().mockResolvedValue(null),
+}))
+
+  import { useShortcuts } from '../src/composables/useShortcuts'
+import { loadKeys } from '../src/utils/storage'
+import type { KeySetting } from '../src/utils/url-matching'
+
+const mockLoadKeys = vi.mocked(loadKeys)
+
+function makeKey(overrides: Partial<KeySetting> = {}): KeySetting {
+  return {
+    id: 'test-id-' + Math.random().toString(36).slice(2),
+    key: 'ctrl+a',
+    action: 'newtab',
+    enabled: true,
+    sites: '',
+    sitesArray: [''],
+    ...overrides,
+  } as KeySetting
+}
+
+describe('dirty tracking', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const { keys } = useShortcuts()
+    keys.value = []
+  })
+
+  it('starts clean after loadSavedKeys with no data', async () => {
+    mockLoadKeys.mockResolvedValueOnce(null)
+    const { dirty, loadSavedKeys } = useShortcuts()
+    await loadSavedKeys()
+    expect(dirty.value).toBe(false)
+  })
+
+  it('starts clean after loadSavedKeys with existing data', async () => {
+    const existing = [makeKey({ key: 'ctrl+a', action: 'newtab' })]
+    mockLoadKeys.mockResolvedValueOnce(JSON.stringify(existing))
+    const { dirty, loadSavedKeys } = useShortcuts()
+    await loadSavedKeys()
+    expect(dirty.value).toBe(false)
+  })
+
+  it('becomes dirty when a shortcut key is changed', async () => {
+    const existing = [makeKey({ key: 'ctrl+a', action: 'newtab' })]
+    mockLoadKeys.mockResolvedValueOnce(JSON.stringify(existing))
+    const { dirty, keys, loadSavedKeys } = useShortcuts()
+    await loadSavedKeys()
+
+    keys.value[0].key = 'ctrl+b'
+    await nextTick()
+    expect(dirty.value).toBe(true)
+  })
+
+  it('becomes dirty when a shortcut action is changed', async () => {
+    const existing = [makeKey({ key: 'ctrl+a', action: 'newtab' })]
+    mockLoadKeys.mockResolvedValueOnce(JSON.stringify(existing))
+    const { dirty, keys, loadSavedKeys } = useShortcuts()
+    await loadSavedKeys()
+
+    keys.value[0].action = 'closetab'
+    await nextTick()
+    expect(dirty.value).toBe(true)
+  })
+
+  it('becomes dirty when a shortcut is added', async () => {
+    mockLoadKeys.mockResolvedValueOnce(JSON.stringify([]))
+    const { dirty, addShortcut, loadSavedKeys } = useShortcuts()
+    await loadSavedKeys()
+
+    addShortcut()
+    await nextTick()
+    expect(dirty.value).toBe(true)
+  })
+
+  it('becomes dirty when enabled is toggled', async () => {
+    const existing = [makeKey({ key: 'ctrl+a', action: 'newtab', enabled: true })]
+    mockLoadKeys.mockResolvedValueOnce(JSON.stringify(existing))
+    const { dirty, keys, toggleEnabled, loadSavedKeys } = useShortcuts()
+    await loadSavedKeys()
+
+    toggleEnabled(keys.value[0])
+    await nextTick()
+    expect(dirty.value).toBe(true)
+  })
+
+  it('becomes clean after saveShortcuts', async () => {
+    const existing = [makeKey({ key: 'ctrl+a', action: 'newtab' })]
+    mockLoadKeys.mockResolvedValueOnce(JSON.stringify(existing))
+    const { dirty, keys, saveShortcuts, loadSavedKeys } = useShortcuts()
+    await loadSavedKeys()
+
+    keys.value[0].key = 'ctrl+b'
+    await nextTick()
+    expect(dirty.value).toBe(true)
+
+    await saveShortcuts()
+    expect(dirty.value).toBe(false)
+  })
+
+  it('becomes clean after deleteShortcut (auto-saves)', async () => {
+    const existing = [
+      makeKey({ key: 'ctrl+a', action: 'newtab' }),
+      makeKey({ key: 'ctrl+b', action: 'closetab' }),
+    ]
+    mockLoadKeys.mockResolvedValueOnce(JSON.stringify(existing))
+    const { dirty, keys, deleteShortcut, loadSavedKeys } = useShortcuts()
+    await loadSavedKeys()
+
+    // Make a change first to set dirty
+    keys.value[0].key = 'ctrl+z'
+    await nextTick()
+    expect(dirty.value).toBe(true)
+
+    // deleteShortcut calls saveShortcuts internally
+    await deleteShortcut(0)
+    expect(dirty.value).toBe(false)
+  })
+
+  it('returns to clean if change is reverted', async () => {
+    const existing = [makeKey({ key: 'ctrl+a', action: 'newtab' })]
+    mockLoadKeys.mockResolvedValueOnce(JSON.stringify(existing))
+    const { dirty, keys, loadSavedKeys } = useShortcuts()
+    await loadSavedKeys()
+
+    keys.value[0].key = 'ctrl+b'
+    await nextTick()
+    expect(dirty.value).toBe(true)
+
+    // Revert the change
+    keys.value[0].key = 'ctrl+a'
+    await nextTick()
+    expect(dirty.value).toBe(false)
+  })
+
+  it('stays clean when no changes are made', async () => {
+    const existing = [makeKey({ key: 'ctrl+a', action: 'newtab' })]
+    mockLoadKeys.mockResolvedValueOnce(JSON.stringify(existing))
+    const { dirty, loadSavedKeys } = useShortcuts()
+    await loadSavedKeys()
+
+    await nextTick()
+    await nextTick()
+    expect(dirty.value).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds dirty tracking to the `useShortcuts` composable using a JSON snapshot comparison approach
- Registers a `beforeunload` handler on the options page that shows the browser's native "unsaved changes" dialog when the user has pending modifications
- Does NOT auto-save — just warns before data loss

## How it works

1. After loading shortcuts (`loadSavedKeys`), a JSON snapshot of the current state is stored
2. A deep watcher on `keys` compares current state against the snapshot — if different, `dirty` is `true`
3. After saving (`saveShortcuts`, `deleteShortcut`), the snapshot is updated and `dirty` resets to `false`
4. If the user reverts their changes manually, `dirty` returns to `false` (smart comparison, not just a flag)
5. On `beforeunload`, if `dirty` is true, `e.preventDefault()` triggers the native browser confirmation dialog

## Tests

10 new tests covering:
- Clean state after load (with and without data)
- Dirty detection on key change, action change, add shortcut, toggle enabled
- Clean after save, clean after delete (auto-saves)
- Smart revert detection (reverting changes clears dirty)
- No false positives when no changes made

All 626 tests pass.