### PR TITLE
docs: add store listing assets for v5 launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ npm run build:firefox  # Firefox → .output/firefox-mv2/
 ```bash
 npm run dev            # Chrome dev mode with hot reload
 npm run dev:firefox    # Firefox dev mode
-npm test               # Run all tests (569 tests across 21 files)
+npm test               # Run all tests (626 tests across 23 files)
 npm run test:watch     # Watch mode
 npm run test:coverage  # With coverage report
 ```
@@ -119,7 +119,8 @@ src/
 └── utils/                   # Storage, URL matching, conflict detection, JS snippets
 
 site/                        # shortkeys.app (Astro SSG, deployed to Netlify)
-tests/                       # 569 tests across 21 files
+tests/                       # 626 tests across 23 files
+marketing/                   # Store listing copy, screenshot plans, promo assets
 ```
 
 ## Tech stack
@@ -127,7 +128,7 @@ tests/                       # 569 tests across 21 files
 - **WXT** - Vite-based browser extension framework
 - **Vue 3** - Composition API with `<script setup>`
 - **TypeScript** throughout
-- **Vitest** - 569 tests across 21 files
+- **Vitest** - 626 tests across 23 files
 - **Mousetrap** - keyboard shortcut detection
 - **CodeMirror 6** - JavaScript editor with syntax highlighting
 - **Astro** - community website (shortkeys.app)

--- a/marketing/STORE-LISTINGS.md
+++ b/marketing/STORE-LISTINGS.md
@@ -1,0 +1,358 @@
+# Store Listing Copy & Assets — Shortkeys v5
+
+> Reference document for Chrome Web Store, Firefox Add-ons (AMO), and Microsoft Edge Add-ons listings.
+> Last updated for v5.0.0.
+
+---
+
+## Table of Contents
+
+- [Short Description (all stores)](#short-description)
+- [Chrome Web Store](#chrome-web-store)
+- [Firefox Add-ons (AMO)](#firefox-add-ons-amo)
+- [Microsoft Edge Add-ons](#microsoft-edge-add-ons)
+- [Screenshot Plan](#screenshot-plan)
+- [Promotional Tiles (Chrome)](#promotional-tiles-chrome)
+- [Store Specs Reference](#store-specs-reference)
+
+---
+
+## Short Description
+
+> Used in the manifest `description` field. Appears as the one-liner in search results across all stores. 132-character max.
+
+```
+Custom keyboard shortcuts for your browser — 120+ actions, macros, shortcut packs, cloud sync, and more. Free and open source.
+```
+
+(125 characters)
+
+---
+
+## Chrome Web Store
+
+> Plain text only. No markdown, no HTML.
+
+### Description
+
+```
+Shortkeys lets you create custom keyboard shortcuts for anything your browser can do. Choose from 120+ built-in actions, chain them into macros, or write your own JavaScript — all with a clean, modern interface.
+
+WHAT CAN IT DO?
+
+Shortkeys ships with 120+ built-in actions across 11 categories:
+
+- Scrolling: scroll up/down/left/right, jump to top or bottom
+- Tabs: open, close, pin, mute, move, sort, duplicate, suspend, group, and switch tabs
+- Navigation: back, forward, reload, copy URL, open from clipboard
+- Windows: new window, new private window, close window, fullscreen
+- Bookmarks: open any bookmark or bookmarklet with a shortcut
+- Zooming: zoom in, zoom out, reset
+- Video controls: play/pause, speed up/down, skip, mute, fullscreen
+- Search: search Google, YouTube, Wikipedia, or GitHub for selected text
+- Page tools: cheat sheet overlay, toggle dark mode on any page
+- Page scripts: 25 ready-to-use scripts (highlight links, remove images, extract emails, and more)
+- Miscellaneous: run custom JavaScript, insert text, trigger other shortcuts, take screenshots, print, and more
+
+MACROS — CHAIN MULTIPLE ACTIONS
+
+Chain up to 10 actions into a single shortcut with optional delays between steps. Example: press one key to open a new tab, navigate to a URL, and pin it.
+
+SHORTCUT PACKS — ONE-CLICK PRESETS
+
+Get started fast with 9 curated shortcut packs:
+
+- Vim Navigation — browse the web with hjkl
+- Emacs Navigation — Emacs-style movement and editing
+- YouTube Power User — speed controls, skip, fullscreen
+- Productivity — tab management and navigation essentials
+- Developer Tools — view source, console, clear cache
+- Speed Reading — scroll, font size, reading mode
+- Tab Manager — advanced tab switching and organization
+- Keyboard Power User — power user essentials
+- Media Control — universal play/pause, skip, volume
+
+COMMAND PALETTE
+
+Click the Shortkeys icon (or set a global shortcut) to open a searchable command palette. Search and trigger any of your shortcuts instantly, or add a new one without opening settings.
+
+MORE FEATURES
+
+- Cloud sync: shortcuts sync across devices via Chrome Sync, with automatic local fallback if your data exceeds the sync quota
+- Groups: organize shortcuts into collapsible, renamable groups with bulk enable/disable
+- Per-site filtering: set any shortcut to work on all sites, all sites except specific ones, or only on specific sites
+- Shortcut recorder: click Record and press your keys — supports multi-key sequences (like "g i" for Gmail-style shortcuts)
+- Conflict detection: warns you when a shortcut conflicts with a browser default (platform-aware for Mac vs Windows/Linux)
+- Shareable links: generate a URL to share individual shortcuts or entire groups with anyone
+- Custom JavaScript: full code editor with syntax highlighting, Greasyfork/userscript import, and a Test button to run scripts in any tab
+- Live reload: saved shortcuts update in all open tabs instantly — no page refresh needed
+- Dark mode: follows your system preference
+- Undo/redo: made a mistake in settings? Ctrl+Z to undo
+- Guided onboarding: new users get a step-by-step wizard
+- Usage analytics: see which shortcuts you use most (local only, never shared)
+
+KEYBOARD SHORTCUTS
+
+Use any combination of modifier keys (Ctrl, Alt, Shift, Cmd/Meta) with letters, numbers, punctuation, or special keys (F1-F19, arrows, Home, End, Page Up/Down, etc.). String multiple combos together for key sequences like "g i" or "ctrl+k ctrl+c".
+
+OPEN SOURCE
+
+Shortkeys is free, open source (MIT license), and has been trusted by 200,000+ Chrome users. Star us on GitHub: https://github.com/crittermike/shortkeys
+
+SUPPORT
+
+- Documentation: https://github.com/mikecrittenden/shortkeys/wiki/How-To-Use-Shortkeys
+- Bug reports and feature requests: https://github.com/crittermike/shortkeys/issues
+- Website: https://shortkeys.app
+
+PERMISSIONS
+
+Shortkeys requests only the permissions it needs. For details on each permission and why it's required, see: https://github.com/mikecrittenden/shortkeys/wiki/FAQs-and-Troubleshooting#why-are-all-these-permissions-required
+```
+
+---
+
+## Firefox Add-ons (AMO)
+
+> Summary: 250-character max, plain text.
+> Description: Markdown supported (headings, lists, bold, italic, links).
+
+### Summary
+
+```
+Create custom keyboard shortcuts for your browser — 120+ built-in actions, macros, shortcut packs, command palette, cloud sync, and more.
+```
+
+(139 characters)
+
+### Description
+
+```markdown
+Shortkeys lets you create custom keyboard shortcuts for anything your browser can do. Choose from **120+ built-in actions**, chain them into **macros**, or write your own JavaScript — all with a clean, modern interface.
+
+## What Can It Do?
+
+**120+ built-in actions** across 11 categories:
+
+- **Scrolling** — scroll up/down/left/right, jump to top or bottom
+- **Tabs** — open, close, pin, mute, move, sort, duplicate, suspend, and switch tabs
+- **Navigation** — back, forward, reload, copy URL, open from clipboard
+- **Windows** — new window, new private window, close window, fullscreen
+- **Bookmarks** — open any bookmark or bookmarklet with a shortcut
+- **Zooming** — zoom in, zoom out, reset
+- **Video controls** — play/pause, speed up/down, skip, mute, fullscreen
+- **Search** — search Google, YouTube, Wikipedia, or GitHub for selected text
+- **Page tools** — cheat sheet overlay, toggle dark mode on any page
+- **Page scripts** — 25 ready-to-use scripts (highlight links, remove images, extract emails, and more)
+- **Miscellaneous** — run custom JavaScript, insert text, trigger other shortcuts, take screenshots, and more
+
+## Macros — Chain Multiple Actions
+
+Chain up to 10 actions into a single shortcut with optional delays between steps. Example: press one key to open a new tab, navigate to a URL, and pin it.
+
+## Shortcut Packs
+
+Get started fast with **9 curated shortcut packs**: Vim, Emacs, YouTube, Productivity, Developer, Reading, Tab Manager, Keyboard Power, and Media Control. One click to install.
+
+## Command Palette
+
+Click the Shortkeys icon to open a **searchable command palette**. Search and trigger any of your shortcuts instantly, or add a new one without opening settings.
+
+## More Features
+
+- **Cloud sync** — shortcuts sync across devices with automatic local fallback
+- **Groups** — organize shortcuts into collapsible, renamable sections
+- **Per-site filtering** — all sites, blocklist, or allowlist per shortcut
+- **Shortcut recorder** — click Record and press your keys, including multi-key sequences
+- **Conflict detection** — platform-aware warnings for browser default clashes
+- **Shareable links** — share shortcuts or groups with anyone via URL
+- **Custom JavaScript** — full code editor with syntax highlighting and userscript import
+- **Live reload** — shortcuts update in all tabs instantly, no refresh needed
+- **Dark mode** — follows your system preference
+- **Undo/redo** — Ctrl+Z / Ctrl+Y in the settings page
+- **Usage analytics** — see which shortcuts you use most (local only)
+
+## Open Source
+
+Free and open source under the MIT license. Trusted by 200,000+ Chrome users.
+
+- [GitHub](https://github.com/crittermike/shortkeys)
+- [Documentation](https://github.com/mikecrittenden/shortkeys/wiki/How-To-Use-Shortkeys)
+- [Bug reports](https://github.com/crittermike/shortkeys/issues)
+- [Website](https://shortkeys.app)
+```
+
+---
+
+## Microsoft Edge Add-ons
+
+> Plain text. Specs not well-documented — follow Chrome format to be safe.
+
+### Description
+
+Use the same copy as the [Chrome Web Store description](#chrome-web-store) above. Edge Add-ons uses plain text and similar formatting constraints.
+
+Note: Some Chrome-specific features may need adjustment for Edge (e.g., "Chrome Sync" → "browser sync"). Tab grouping (`chrome.tabs.group`) is supported in Edge.
+
+---
+
+## Screenshot Plan
+
+> All screenshots should be **1280×800 pixels**, JPEG or 24-bit PNG (no transparency). 16:10 aspect ratio. Chrome allows up to 5.
+
+### How to Capture
+
+Use the `npm run visual-review` script to build and launch the extension headlessly, then capture screenshots. Or load the built extension manually in Chrome and use a full-page screenshot tool at exactly 1280×800 viewport.
+
+For the best results:
+- Use a clean Chrome profile (no other extensions in toolbar)
+- Use a 1280×800 viewport (or 2560×1600 for 2x retina, then downscale)
+- Populate with realistic shortcut data (not "test" or "asdf")
+- Light mode for screenshots 1-4, dark mode for screenshot 5
+
+### Slot 1: Options Page — Groups & Shortcuts
+
+**What to show:** The main options page with 2-3 groups expanded, showing 5-7 realistic shortcuts (e.g., "Vim Navigation" group with hjkl scrolling, a "Tab Management" group with next/previous tab shortcuts). The search bar and stats bar should be visible at the top.
+
+**Why:** First impression. Shows the clean, modern v5 UI with groups, toggle switches, and the overall layout.
+
+**Setup:**
+- Import the Vim and Productivity packs
+- Expand both groups
+- Ensure the stats bar shows "X shortcuts" and the search field is visible
+- Light mode
+
+### Slot 2: Command Palette
+
+**What to show:** The popup command palette with a search query partially typed (e.g., "new") showing filtered results like "New tab", "New window", "New private window". The Quick Add form should not be open — show the search/trigger mode.
+
+**Why:** The command palette is a unique differentiator. Most shortcut extensions don't have one.
+
+**Setup:**
+- Have 8-10 shortcuts configured
+- Open the popup
+- Type "new" in the search field
+- Screenshot the popup at its natural size, centered on a neutral background page
+
+### Slot 3: Macros / Chaining
+
+**What to show:** A macro shortcut expanded, showing 3-4 chained actions (e.g., "Morning routine" → New tab → Navigate to URL → Pin tab). The delay fields and step controls should be visible.
+
+**Why:** Macros are a powerful v5 feature that competitors don't have.
+
+**Setup:**
+- Create a "Macros" group
+- Add a "Morning routine" shortcut with macro steps
+- Expand it to show the step list
+- Light mode
+
+### Slot 4: Import — Shortcut Packs
+
+**What to show:** The Import tab with the shortcut pack browser visible, showing the grid of 9 pack cards (Vim, Emacs, YouTube, etc.) with their icons, names, and descriptions.
+
+**Why:** Packs make Shortkeys instantly useful for new users. Great "wow, there's a lot here" moment.
+
+**Setup:**
+- Click the "Import" tab
+- Scroll to the pack browser section
+- Ensure all 9 pack cards are visible in the grid
+- Light mode
+
+### Slot 5: Dark Mode
+
+**What to show:** The options page in dark mode with 2-3 groups of shortcuts visible. Similar content to Slot 1 but in dark theme.
+
+**Why:** Dark mode is table stakes but still worth showing — it signals a polished, modern extension.
+
+**Setup:**
+- Same shortcut data as Slot 1
+- Toggle to dark mode
+- Screenshot
+
+### Firefox & Edge Notes
+
+- Use the same 5 screenshots for all stores
+- Firefox has no strict dimension requirement but 1280×800 works well
+- Edge likely follows Chrome's specs
+
+---
+
+## Promotional Tiles (Chrome)
+
+> Chrome Web Store allows optional promotional images that appear in featured/recommended sections.
+
+### Small Promotional Tile (440×280)
+
+**Concept:** Shortkeys logo on the left, tagline on the right. Clean, minimal.
+
+```
+Layout:
+┌──────────────────────────────────┐
+│                                  │
+│   ⌨️  Shortkeys                  │
+│                                  │
+│   Custom keyboard shortcuts      │
+│   for your browser               │
+│                                  │
+│   120+ actions · Macros · Packs  │
+│                                  │
+└──────────────────────────────────┘
+```
+
+- Background: white or very light gray (#f8f9fa)
+- Logo: the Shortkeys icon (public/images/icon_128.png)
+- Font: system sans-serif, bold for "Shortkeys", regular for tagline
+- Accent: the Shortkeys blue (#4361ee)
+
+### Marquee Promotional Tile (1400×560)
+
+**Concept:** Left side shows the Shortkeys logo and tagline. Right side shows a cropped screenshot of the options page (the groups view).
+
+```
+Layout:
+┌──────────────────────────────────────────────────────────┐
+│                         │                                │
+│   ⌨️  Shortkeys         │   [Cropped screenshot of       │
+│                         │    options page with groups     │
+│   Custom keyboard       │    and shortcuts visible]       │
+│   shortcuts for         │                                │
+│   your browser          │                                │
+│                         │                                │
+│   ★ 200K+ users         │                                │
+│                         │                                │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Store Specs Reference
+
+| | Chrome Web Store | Firefox Add-ons | Edge Add-ons |
+|---|---|---|---|
+| **Short description** | 132 chars (from manifest) | 250 chars (summary field) | 132 chars (from manifest) |
+| **Long description** | ~16,000 chars, plain text | Unlimited, Markdown | Not documented, plain text |
+| **Screenshots** | 1–5, 1280×800 or 640×400, JPEG/PNG | 1+, no strict size, PNG/JPEG | 1+, likely 1280×800 |
+| **Promo tile (small)** | 440×280 | N/A | N/A |
+| **Promo tile (marquee)** | 1400×560 | N/A | N/A |
+| **Icon** | 128×128 PNG | 128×128 PNG | 128×128 PNG |
+
+---
+
+## Changelog Highlights for Listing (v5 vs v4)
+
+Use these when stores have a "What's new" or changelog section:
+
+- Completely redesigned settings page with modern UI
+- Command palette popup — search and trigger shortcuts instantly
+- Macros — chain up to 10 actions into a single shortcut
+- 9 curated shortcut packs (Vim, Emacs, YouTube, and more)
+- Groups — organize shortcuts into collapsible sections
+- Usage analytics dashboard
+- Shareable links for shortcuts and groups
+- Community pack browser
+- Shortcut conflict detection
+- Undo/redo in settings
+- Guided onboarding for new users
+- Cloud sync with automatic local fallback
+- 25 built-in page scripts
+- Full backward compatibility with v4 data


### PR DESCRIPTION
## Summary

Closes #721

- Adds `marketing/STORE-LISTINGS.md` with ready-to-use store copy for Chrome Web Store, Firefox Add-ons, and Edge Add-ons
- Includes detailed screenshot plan for all 5 Chrome Web Store slots with setup instructions
- Includes promotional tile concepts (440×280 small tile, 1400×560 marquee)
- Updates README.md test counts (569→626 tests, 21→23 files) and adds `marketing/` to project structure

## What's in STORE-LISTINGS.md

- **Short description** (125 chars) — shared across all stores
- **Chrome Web Store** — full plain-text description (~1,200 chars)
- **Firefox Add-ons** — Markdown-formatted description with headings, bold, and lists
- **Edge Add-ons** — guidance to reuse Chrome copy
- **Screenshot plan** — 5 slots covering options page, command palette, macros, packs import, and dark mode
- **Promo tile concepts** — small (440×280) and marquee (1400×560) with copy suggestions
- **Store specs reference** — character limits, image dimensions, format requirements per store
- **v5 changelog highlights** — key improvements over v4 for "What's New" sections

Actual screenshot images are not included — the doc describes what to capture and how to set up each shot. These can be created separately using the visual-review script or manually.