### PR TITLE
Fix onboarding success panel alignment

### DIFF
--- a/src/components/OnboardingWizard.vue
+++ b/src/components/OnboardingWizard.vue
@@ -726,6 +726,7 @@ const skip = () => {
 .success-summary {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: var(--space-lg);
   background: var(--bg-elevated);
   padding: 16px 24px;


### PR DESCRIPTION
## Summary
- Adds `justify-content: center` to `.success-summary` so both shortcut rows (kbd keys → arrow → action) and pack rows (emoji → name + count) are consistently centered within their cards on the step 3 success panel.

Fixes the alignment inconsistency noted after merging #774.