### PR TITLE
Fix drag-and-drop intercepting text selection in inputs

### DIFF
--- a/src/composables/useDragDrop.ts
+++ b/src/composables/useDragDrop.ts
@@ -7,8 +7,22 @@ export function useDragDrop() {
   const { keys } = useShortcuts()
 
   const dragIndex = ref<number | null>(null)
+  const handleActive = ref(false)
 
-  function onDragStart(index: number) {
+  function onHandleMouseDown() {
+    handleActive.value = true
+    const onUp = () => {
+      handleActive.value = false
+      document.removeEventListener('mouseup', onUp)
+    }
+    document.addEventListener('mouseup', onUp)
+  }
+
+  function onDragStart(e: DragEvent, index: number) {
+    if (!handleActive.value) {
+      e.preventDefault()
+      return
+    }
     const { pushUndo } = useUndoRedo()
     pushUndo('Shortcuts reordered')
     dragIndex.value = index
@@ -36,5 +50,5 @@ export function useDragDrop() {
     dragIndex.value = null
   }
 
-  return { dragIndex, onDragStart, onDragOver, onDragOverGroup, onDragEnd }
+  return { dragIndex, handleActive, onHandleMouseDown, onDragStart, onDragOver, onDragOverGroup, onDragEnd }
 }

--- a/src/entrypoints/options/App.vue
+++ b/src/entrypoints/options/App.vue
@@ -46,7 +46,7 @@ const {
   loadGroupSettingsFromStorage, persistGroupSettings,
 } = useGroups()
 const { convertToMacro } = useMacros()
-const { dragIndex, onDragStart, onDragOver, onDragOverGroup, onDragEnd } = useDragDrop()
+const { dragIndex, handleActive, onHandleMouseDown, onDragStart, onDragOver, onDragOverGroup, onDragEnd } = useDragDrop()
 const { shareGroup, publishToCommunity } = useImportExport()
 const { refreshTabs, loadBookmarks } = useJsTools()
 const { init: initUndoRedo, undo, redo, canUndo, canRedo } = useUndoRedo()
@@ -352,14 +352,14 @@ onUnmounted(() => {
                 v-for="index in (groupedIndices.get(group) || [])"
                 :key="keys[index].id"
                 :class="['shortcut-card', { disabled: keys[index].enabled === false, dragging: dragIndex === index, expanded: expandedRow === index }]"
-                draggable="true"
-                @dragstart="onDragStart(index)"
+                :draggable="handleActive"
+                @dragstart="onDragStart($event, index)"
                 @dragover="onDragOver($event, index)"
                 @dragend="onDragEnd"
               >
                 <!-- Editable label above the card -->
                 <div class="shortcut-header">
-                  <i class="mdi mdi-drag-vertical drag-handle" title="Drag to reorder"></i>
+                  <i class="mdi mdi-drag-vertical drag-handle" title="Drag to reorder" @mousedown="onHandleMouseDown"></i>
                   <input
                     class="shortcut-label-title"
                     type="text"

--- a/tests/drag-drop.test.ts
+++ b/tests/drag-drop.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/utils/storage', () => ({
+  saveKeys: vi.fn().mockResolvedValue('sync'),
+  loadKeys: vi.fn().mockResolvedValue(null),
+}))
+
+import { useDragDrop } from '../src/composables/useDragDrop'
+import { useShortcuts } from '../src/composables/useShortcuts'
+import { useUndoRedo } from '../src/composables/useUndoRedo'
+import { ref } from 'vue'
+import type { KeySetting } from '../src/utils/url-matching'
+
+function makeKey(overrides: Partial<KeySetting> = {}): KeySetting {
+  return {
+    id: 'test-id-' + Math.random().toString(36).slice(2),
+    key: 'ctrl+a',
+    action: 'newtab',
+    enabled: true,
+    sites: '',
+    sitesArray: [''],
+    ...overrides,
+  } as KeySetting
+}
+
+function makeDragEvent(overrides: Partial<DragEvent> = {}): DragEvent {
+  return {
+    preventDefault: vi.fn(),
+    ...overrides,
+  } as unknown as DragEvent
+}
+
+describe('useDragDrop', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const { keys } = useShortcuts()
+    keys.value = []
+    const { undoStack, redoStack, lastActionLabel, init } = useUndoRedo()
+    undoStack.value = []
+    redoStack.value = []
+    lastActionLabel.value = ''
+    init(ref<KeySetting[]>([]))
+  })
+
+  describe('handle-gated dragging', () => {
+    it('handleActive is false by default', () => {
+      const { handleActive } = useDragDrop()
+      expect(handleActive.value).toBe(false)
+    })
+
+    it('onHandleMouseDown sets handleActive to true', () => {
+      const { handleActive, onHandleMouseDown } = useDragDrop()
+      onHandleMouseDown()
+      expect(handleActive.value).toBe(true)
+    })
+
+    it('mouseup resets handleActive to false', () => {
+      const { handleActive, onHandleMouseDown } = useDragDrop()
+      onHandleMouseDown()
+      expect(handleActive.value).toBe(true)
+      document.dispatchEvent(new MouseEvent('mouseup'))
+      expect(handleActive.value).toBe(false)
+    })
+
+    it('onDragStart is prevented when handle is not active', () => {
+      const { keys } = useShortcuts()
+      keys.value = [makeKey()]
+      const { onDragStart, dragIndex } = useDragDrop()
+      const event = makeDragEvent()
+      onDragStart(event, 0)
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(dragIndex.value).toBeNull()
+    })
+
+    it('onDragStart proceeds when handle is active', () => {
+      const { keys } = useShortcuts()
+      keys.value = [makeKey()]
+      const { init } = useUndoRedo()
+      init(keys)
+      const { onHandleMouseDown, onDragStart, dragIndex } = useDragDrop()
+      onHandleMouseDown()
+      const event = makeDragEvent()
+      onDragStart(event, 0)
+      expect(event.preventDefault).not.toHaveBeenCalled()
+      expect(dragIndex.value).toBe(0)
+    })
+
+    it('mouseup listener is cleaned up after firing', () => {
+      const { handleActive, onHandleMouseDown } = useDragDrop()
+      onHandleMouseDown()
+      document.dispatchEvent(new MouseEvent('mouseup'))
+      expect(handleActive.value).toBe(false)
+
+      // A second mouseup should not change anything (listener was removed)
+      handleActive.value = true
+      document.dispatchEvent(new MouseEvent('mouseup'))
+      expect(handleActive.value).toBe(true)
+    })
+  })
+
+  describe('drag operations', () => {
+    it('onDragOver reorders items', () => {
+      const { keys } = useShortcuts()
+      keys.value = [makeKey({ key: 'a' }), makeKey({ key: 'b' }), makeKey({ key: 'c' })]
+      const { init } = useUndoRedo()
+      init(keys)
+      const { onHandleMouseDown, onDragStart, onDragOver, dragIndex } = useDragDrop()
+
+      // Start drag from index 0
+      onHandleMouseDown()
+      onDragStart(makeDragEvent(), 0)
+      expect(dragIndex.value).toBe(0)
+
+      // Drag over index 2
+      onDragOver(makeDragEvent(), 2)
+      expect(keys.value[2].key).toBe('a')
+      expect(dragIndex.value).toBe(2)
+    })
+
+    it('onDragEnd resets dragIndex', () => {
+      const { keys } = useShortcuts()
+      keys.value = [makeKey()]
+      const { init } = useUndoRedo()
+      init(keys)
+      const { onHandleMouseDown, onDragStart, onDragEnd, dragIndex } = useDragDrop()
+
+      onHandleMouseDown()
+      onDragStart(makeDragEvent(), 0)
+      expect(dragIndex.value).toBe(0)
+      onDragEnd()
+      expect(dragIndex.value).toBeNull()
+    })
+
+    it('onDragOver does nothing if dragIndex is null', () => {
+      const { keys } = useShortcuts()
+      keys.value = [makeKey({ key: 'a' }), makeKey({ key: 'b' })]
+      const { onDragOver } = useDragDrop()
+      const originalOrder = keys.value.map((k) => k.key)
+      onDragOver(makeDragEvent(), 1)
+      expect(keys.value.map((k) => k.key)).toEqual(originalOrder)
+    })
+
+    it('onDragOver does nothing if dragging over same index', () => {
+      const { keys } = useShortcuts()
+      keys.value = [makeKey({ key: 'a' }), makeKey({ key: 'b' })]
+      const { init } = useUndoRedo()
+      init(keys)
+      const { onHandleMouseDown, onDragStart, onDragOver } = useDragDrop()
+      onHandleMouseDown()
+      onDragStart(makeDragEvent(), 0)
+      const originalOrder = keys.value.map((k) => k.key)
+      onDragOver(makeDragEvent(), 0)
+      expect(keys.value.map((k) => k.key)).toEqual(originalOrder)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes the bug where drag-selecting text in shortcut title, "Except", and "Only on" inputs would trigger drag-and-drop reordering instead ([reported in #695](https://github.com/crittermike/shortkeys/issues/695#issuecomment-3998929305))
- Cards are now only `draggable` when the user mousedowns on the drag handle icon, leaving all other interactions (text selection, clicking, etc.) unaffected
- Adds 10 tests for the drag-drop composable covering handle gating, reorder operations, and listener cleanup

## Changes

**`src/composables/useDragDrop.ts`**
- Added `handleActive` ref and `onHandleMouseDown()` — sets `handleActive` to true on mousedown, resets on document mouseup (with self-removing listener)
- `onDragStart` now takes the `DragEvent` and calls `e.preventDefault()` + returns early if the drag handle wasn't pressed

**`src/entrypoints/options/App.vue`**
- Shortcut card `draggable` is now bound to `handleActive` instead of hardcoded `"true"`
- `@dragstart` passes `$event` to the updated `onDragStart`
- Drag handle icon has `@mousedown="onHandleMouseDown"`

**`tests/drag-drop.test.ts`** (new)
- 10 tests covering: default state, handle activation, mouseup reset, drag prevention without handle, drag success with handle, listener cleanup, reorder, drag end, null/same-index guards