### PR TITLE
Fix: Command palette doesn't scroll with arrow key navigation

### DIFF
--- a/src/entrypoints/popup/App.vue
+++ b/src/entrypoints/popup/App.vue
@@ -91,15 +91,24 @@ function onKeydown(e: KeyboardEvent) {
   if (e.key === 'ArrowDown') {
     e.preventDefault()
     selectedIndex.value = Math.min(selectedIndex.value + 1, filtered.value.length - 1)
+    scrollToSelected()
   } else if (e.key === 'ArrowUp') {
     e.preventDefault()
     selectedIndex.value = Math.max(selectedIndex.value - 1, 0)
+    scrollToSelected()
   } else if (e.key === 'Enter') {
     e.preventDefault()
     if (filtered.value[selectedIndex.value]) {
       triggerShortcut(filtered.value[selectedIndex.value])
     }
   }
+}
+
+function scrollToSelected() {
+  nextTick(() => {
+    const el = document.querySelector('.result-row.selected') as HTMLElement | null
+    el?.scrollIntoView({ block: 'nearest' })
+  })
 }
 
 function openSettings() {


### PR DESCRIPTION
## Summary

- Fixes #773: When navigating shortcuts in the command palette popup with arrow keys, the view now scrolls to keep the selected item visible.

## What changed

Added a `scrollToSelected()` function that runs after each arrow key press. It uses `nextTick` to wait for Vue to update the DOM, then calls `scrollIntoView({ block: 'nearest' })` on the currently selected `.result-row` element. This keeps the selection visible whether scrolling down or back up through a long list.

## Testing

All 681 tests pass.