### PR TITLE
Add vertical spacing between behavior dropdown items

### DIFF
--- a/src/components/SearchSelect.vue
+++ b/src/components/SearchSelect.vue
@@ -239,6 +239,7 @@ watch(isOpen, (val) => {
   display: block;
   width: 100%;
   padding: 7px var(--space-md) 7px 12px;
+  margin: 3px 0;
   border: none;
   border-radius: var(--radius-md);
   background: none;


### PR DESCRIPTION
## Summary

Adds 3px vertical margin between items in the SearchSelect dropdown so their highlighted backgrounds don't butt into each other.

## Changes

- **SearchSelect.vue**: Added `margin: 3px 0` to `.ss-option`