### PR TITLE
Add extension details link to the Allow User Scripts warning

### DIFF
--- a/src/entrypoints/options/App.vue
+++ b/src/entrypoints/options/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
 import { ACTION_CATEGORIES, getActionOptionsForSelect } from '@/utils/actions-registry'
+import { getExtensionManagementUrl, openExtensionManagementPage } from '@/utils/extension-management'
 import SearchSelect from '@/components/SearchSelect.vue'
 import ShortcutRecorder from '@/components/ShortcutRecorder.vue'
 import ShortcutDetails from '@/components/ShortcutDetails.vue'
@@ -60,6 +61,7 @@ initDensity()
 
 const activeTab = ref(0)
 const showOnboarding = ref(false)
+const extensionManagementUrl = getExtensionManagementUrl()
 
 const handleWizardFinish = async (shortcut: { key: string; action: string }) => {
   addShortcut()
@@ -184,7 +186,16 @@ onUnmounted(() => {
         <article v-if="needsUserScripts()" class="alert alert-warning">
           <i class="mdi mdi-alert-circle-outline"></i>
           <div>
-            <strong>Allow User Scripts</strong> — In order for JavaScript actions to work, you must first allow User Scripts in your browser extension details page. Then come back and save your shortcuts.
+            <strong>Allow User Scripts</strong> — In order for JavaScript actions to work, you must first allow User Scripts in your browser extension details page.
+            <a
+              :href="extensionManagementUrl"
+              class="alert-link"
+              rel="noreferrer"
+              @click.prevent="openExtensionManagementPage()"
+            >
+              Open extension details
+            </a>
+            and then come back and save your shortcuts.
           </div>
         </article>
 
@@ -1629,6 +1640,13 @@ a:hover { text-decoration: underline; }
   flex-shrink: 0;
   margin-top: 1px;
 }
+.alert-link {
+  color: inherit;
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.alert-link:hover { color: inherit; }
 
 /* ── Buttons ── */
 .action-bar {

--- a/src/utils/extension-management.ts
+++ b/src/utils/extension-management.ts
@@ -1,0 +1,28 @@
+type ExtensionManagementUrlOptions = {
+  userAgent?: string
+  extensionId?: string
+}
+
+function getChromeApi() {
+  return (globalThis as typeof globalThis & { chrome?: typeof chrome }).chrome
+}
+
+function getBrowserScheme(userAgent: string): 'chrome' | 'edge' | 'opera' {
+  if (userAgent.includes('Edg/')) return 'edge'
+  if (userAgent.includes('OPR/')) return 'opera'
+  return 'chrome'
+}
+
+export function getExtensionManagementUrl(options: ExtensionManagementUrlOptions = {}): string {
+  const userAgent = options.userAgent ?? (typeof navigator === 'undefined' ? '' : navigator.userAgent || '')
+  if (userAgent.includes('Firefox')) return 'about:addons'
+
+  const extensionId = options.extensionId ?? getChromeApi()?.runtime?.id
+  const baseUrl = `${getBrowserScheme(userAgent)}://extensions`
+  return extensionId ? `${baseUrl}/?id=${encodeURIComponent(extensionId)}` : baseUrl
+}
+
+export async function openExtensionManagementPage(options: ExtensionManagementUrlOptions = {}): Promise<void> {
+  const url = getExtensionManagementUrl(options)
+  await getChromeApi()?.tabs?.create?.({ url, active: true })
+}

--- a/tests/extension-management.test.ts
+++ b/tests/extension-management.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getExtensionManagementUrl, openExtensionManagementPage } from '../src/utils/extension-management'
+
+const mockTabsCreate = vi.fn()
+
+// @ts-ignore
+globalThis.chrome = {
+  runtime: { id: 'test-extension-id' },
+  tabs: { create: mockTabsCreate },
+}
+
+describe('extension management helper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the Chrome extension details URL by default', () => {
+    expect(getExtensionManagementUrl({
+      userAgent: 'Mozilla/5.0 Chrome/137.0.0.0 Safari/537.36',
+    })).toBe('chrome://extensions/?id=test-extension-id')
+  })
+
+  it('returns the Edge extension details URL', () => {
+    expect(getExtensionManagementUrl({
+      userAgent: 'Mozilla/5.0 Chrome/137.0.0.0 Safari/537.36 Edg/137.0.0.0',
+    })).toBe('edge://extensions/?id=test-extension-id')
+  })
+
+  it('returns the Opera extension details URL', () => {
+    expect(getExtensionManagementUrl({
+      userAgent: 'Mozilla/5.0 Chrome/137.0.0.0 Safari/537.36 OPR/116.0.0.0',
+    })).toBe('opera://extensions/?id=test-extension-id')
+  })
+
+  it('returns the Firefox add-ons page', () => {
+    expect(getExtensionManagementUrl({
+      userAgent: 'Mozilla/5.0 Firefox/137.0',
+    })).toBe('about:addons')
+  })
+
+  it('falls back to the generic extensions page when no extension id is available', () => {
+    expect(getExtensionManagementUrl({
+      userAgent: 'Mozilla/5.0 Chrome/137.0.0.0 Safari/537.36',
+      extensionId: '',
+    })).toBe('chrome://extensions')
+  })
+
+  it('opens the extension management page in a new active tab', async () => {
+    await openExtensionManagementPage({
+      userAgent: 'Mozilla/5.0 Chrome/137.0.0.0 Safari/537.36',
+    })
+
+    expect(mockTabsCreate).toHaveBeenCalledWith({
+      url: 'chrome://extensions/?id=test-extension-id',
+      active: true,
+    })
+  })
+})

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -227,6 +227,15 @@ describe('App.vue template correctness', () => {
     const strayRowBindings = template.match(/(?:v-model|v-if|:modelValue|@click|:class)="[^"]*\brow\b[^"]*"/g) || []
     expect(strayRowBindings, `Found stray row bindings: ${strayRowBindings.join(', ')}`).toHaveLength(0)
   })
+
+  it('includes an extension details link in the Allow User Scripts alert', async () => {
+    const fs = await import('fs')
+    const content = fs.readFileSync('src/entrypoints/options/App.vue', 'utf-8')
+
+    expect(content).toMatch(/<article v-if="needsUserScripts\(\)"[\s\S]*Open extension details[\s\S]*<\/article>/)
+    expect(content).toContain(':href="extensionManagementUrl"')
+    expect(content).toContain('@click.prevent="openExtensionManagementPage()"')
+  })
 })
 
 describe('v4.x → v5.0 migration compatibility', () => {


### PR DESCRIPTION
## Summary
- add a browser-aware helper for extension management URLs
- link the existing "Allow User Scripts" warning to the extension details page
- cover the helper and template wiring with tests

## Testing
- npm test
- npm run build
- npm run visual-review

Closes #790