### PR TITLE
Migrate options page to Tailwind CSS v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,14 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
+        "@tailwindcss/postcss": "^4.2.1",
         "@types/chrome": "^0.0.267",
         "@vitest/coverage-v8": "^3.2.4",
         "@wxt-dev/module-vue": "^1.0.3",
         "astro": "^5.18.0",
         "jsdom": "^27.0.1",
+        "postcss": "^8.5.8",
+        "tailwindcss": "^4.2.1",
         "vitest": "^3.2.4",
         "wxt": "^0.20.17"
       }
@@ -134,6 +137,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2301,6 +2317,277 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
+      "integrity": "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.31.1",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.1.tgz",
+      "integrity": "sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.1",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.1",
+        "@tailwindcss/oxide-darwin-x64": "4.2.1",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.1",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.1",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.1",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.1",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.1",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.1",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.1",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.1",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.1.tgz",
+      "integrity": "sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.1.tgz",
+      "integrity": "sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.1.tgz",
+      "integrity": "sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.1.tgz",
+      "integrity": "sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.1.tgz",
+      "integrity": "sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.1.tgz",
+      "integrity": "sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.1.tgz",
+      "integrity": "sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.1.tgz",
+      "integrity": "sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.1.tgz",
+      "integrity": "sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.1.tgz",
+      "integrity": "sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz",
+      "integrity": "sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.1.tgz",
+      "integrity": "sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.1.tgz",
+      "integrity": "sha512-OEwGIBnXnj7zJeonOh6ZG9woofIjGrd2BORfvE5p9USYKDCZoQmfqLcfNiRWoJlRWLdNPn2IgVZuWAOM4iTYMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.2.1",
+        "@tailwindcss/oxide": "4.2.1",
+        "postcss": "^8.5.6",
+        "tailwindcss": "4.2.1"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -4884,7 +5171,6 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5125,6 +5411,20 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -6700,6 +7000,267 @@
       "dependencies": {
         "debug": "^4.4.1",
         "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
+      "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.31.1",
+        "lightningcss-darwin-arm64": "1.31.1",
+        "lightningcss-darwin-x64": "1.31.1",
+        "lightningcss-freebsd-x64": "1.31.1",
+        "lightningcss-linux-arm-gnueabihf": "1.31.1",
+        "lightningcss-linux-arm64-gnu": "1.31.1",
+        "lightningcss-linux-arm64-musl": "1.31.1",
+        "lightningcss-linux-x64-gnu": "1.31.1",
+        "lightningcss-linux-x64-musl": "1.31.1",
+        "lightningcss-win32-arm64-msvc": "1.31.1",
+        "lightningcss-win32-x64-msvc": "1.31.1"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.31.1.tgz",
+      "integrity": "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.31.1.tgz",
+      "integrity": "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.31.1.tgz",
+      "integrity": "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.31.1.tgz",
+      "integrity": "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.31.1.tgz",
+      "integrity": "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.31.1.tgz",
+      "integrity": "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.31.1.tgz",
+      "integrity": "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz",
+      "integrity": "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.31.1.tgz",
+      "integrity": "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.31.1.tgz",
+      "integrity": "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz",
+      "integrity": "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lines-and-columns": {
@@ -8748,9 +9309,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "funding": [
         {
           "type": "opencollective",
@@ -10139,6 +10700,27 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
+      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/test-exclude": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,14 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
+    "@tailwindcss/postcss": "^4.2.1",
     "@types/chrome": "^0.0.267",
     "@vitest/coverage-v8": "^3.2.4",
     "@wxt-dev/module-vue": "^1.0.3",
     "astro": "^5.18.0",
     "jsdom": "^27.0.1",
+    "postcss": "^8.5.8",
+    "tailwindcss": "^4.2.1",
     "vitest": "^3.2.4",
     "wxt": "^0.20.17"
   },

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};

--- a/src/components/AnalyticsTab.vue
+++ b/src/components/AnalyticsTab.vue
@@ -31,61 +31,61 @@ function timeAgo(ts: number): string {
 </script>
 
 <template>
-  <div v-if="!loaded" class="analytics-loading">
-    <i class="mdi mdi-loading mdi-spin"></i> Loading analytics...
+  <div v-if="!loaded" class="flex flex-col items-center justify-center py-12 px-6 text-center text-text-muted text-sm">
+    <i class="mdi mdi-loading mdi-spin mr-1.5"></i> Loading analytics...
   </div>
 
-  <div v-else class="analytics-tab">
+  <div v-else>
     <!-- Header -->
-    <div class="analytics-header">
-      <div class="analytics-summary">
-        <div class="summary-stat">
-          <span class="summary-number">{{ totalUsage }}</span>
-          <span class="summary-label">total triggers</span>
+    <div class="flex items-center justify-between mb-6 flex-wrap gap-3">
+      <div class="flex gap-6">
+        <div class="flex flex-col gap-1 relative after:content-[''] after:absolute after:-right-3 after:top-[10%] after:h-[80%] after:w-px after:bg-border-default after:opacity-50 last:after:hidden">
+          <span class="text-4xl font-bold text-text-primary leading-none tracking-tight">{{ totalUsage }}</span>
+          <span class="text-[13px] text-text-muted font-medium">total triggers</span>
         </div>
-        <div class="summary-stat">
-          <span class="summary-number">{{ mostUsed.length }}</span>
-          <span class="summary-label">shortcuts used</span>
+        <div class="flex flex-col gap-1 relative after:content-[''] after:absolute after:-right-3 after:top-[10%] after:h-[80%] after:w-px after:bg-border-default after:opacity-50 last:after:hidden">
+          <span class="text-4xl font-bold text-text-primary leading-none tracking-tight">{{ mostUsed.length }}</span>
+          <span class="text-[13px] text-text-muted font-medium">shortcuts used</span>
         </div>
-        <div class="summary-stat">
-          <span class="summary-number">{{ unusedShortcuts.length }}</span>
-          <span class="summary-label">never used</span>
+        <div class="flex flex-col gap-1">
+          <span class="text-4xl font-bold text-text-primary leading-none tracking-tight">{{ unusedShortcuts.length }}</span>
+          <span class="text-[13px] text-text-muted font-medium">never used</span>
         </div>
       </div>
-      <div class="analytics-actions">
-        <label class="toggle-label">
-          <input type="checkbox" :checked="trackingEnabled" @change="toggleTracking" />
+      <div class="flex items-center gap-3">
+        <label class="flex items-center gap-1.5 text-sm text-text-secondary cursor-pointer select-none">
+          <input type="checkbox" class="w-4 h-4 accent-accent cursor-pointer" :checked="trackingEnabled" @change="toggleTracking" />
           <span>Track usage</span>
         </label>
-        <button class="btn-clear" @click="clearAnalytics" type="button">
-          <i class="mdi mdi-delete-outline"></i> Clear data
+        <button class="inline-flex items-center gap-1.5 px-3.5 py-1.5 border border-border-default rounded-lg bg-surface-elevated text-text-secondary text-[13px] cursor-pointer whitespace-nowrap transition-all duration-200 hover:bg-surface-hover hover:text-danger hover:border-danger" @click="clearAnalytics" type="button">
+          <i class="mdi mdi-delete-outline text-[15px]"></i> Clear data
         </button>
       </div>
     </div>
 
     <!-- Usage over time chart -->
-    <div class="analytics-section" v-if="totalUsage > 0 || mostUsed.length > 0">
-      <div class="section-header">
-        <h3 class="section-title">Usage over time</h3>
-        <div class="chart-period-toggle">
+    <div class="mb-8" v-if="totalUsage > 0 || mostUsed.length > 0">
+      <div class="flex items-center justify-between mb-3">
+        <h3 class="text-base font-bold text-text-primary mb-0">Usage over time</h3>
+        <div class="flex bg-surface-elevated rounded-lg p-0.5 gap-0.5 border border-border-light">
           <button
-            :class="['period-btn', { active: chartPeriod === 7 }]"
+            :class="['px-3 py-1 border-none rounded-md bg-transparent text-text-secondary text-xs font-medium cursor-pointer transition-all duration-200 hover:text-text-primary', chartPeriod === 7 && '!bg-accent !text-white !shadow-sm !font-semibold']"
             @click="chartPeriod = 7"
             type="button"
           >7 days</button>
           <button
-            :class="['period-btn', { active: chartPeriod === 30 }]"
+            :class="['px-3 py-1 border-none rounded-md bg-transparent text-text-secondary text-xs font-medium cursor-pointer transition-all duration-200 hover:text-text-primary', chartPeriod === 30 && '!bg-accent !text-white !shadow-sm !font-semibold']"
             @click="chartPeriod = 30"
             type="button"
           >30 days</button>
         </div>
       </div>
-      <div class="chart-container">
-        <svg class="usage-chart" viewBox="0 0 600 160" preserveAspectRatio="none">
+      <div class="relative bg-surface-elevated border border-border-light rounded-[14px] p-5 pb-6">
+        <svg class="w-full h-40" viewBox="0 0 600 160" preserveAspectRatio="none">
           <!-- Grid lines -->
-          <line x1="0" y1="40" x2="600" y2="40" class="chart-grid" />
-          <line x1="0" y1="80" x2="600" y2="80" class="chart-grid" />
-          <line x1="0" y1="120" x2="600" y2="120" class="chart-grid" />
+          <line x1="0" y1="40" x2="600" y2="40" class="stroke-border-light" stroke-width="1" stroke-dasharray="4 4" />
+          <line x1="0" y1="80" x2="600" y2="80" class="stroke-border-light" stroke-width="1" stroke-dasharray="4 4" />
+          <line x1="0" y1="120" x2="600" y2="120" class="stroke-border-light" stroke-width="1" stroke-dasharray="4 4" />
           <!-- Bars -->
           <g v-for="(bar, i) in chartData" :key="bar.date">
             <rect
@@ -93,16 +93,16 @@ function timeAgo(ts: number): string {
               :y="140 - (bar.total / chartMax * 120)"
               :width="Math.max(2, (600 / chartData.length) - 4)"
               :height="Math.max(bar.total > 0 ? 2 : 0, bar.total / chartMax * 120)"
-              class="chart-bar"
+              class="fill-accent opacity-85 transition-all duration-200 hover:opacity-100 hover:brightness-110"
               rx="2"
             />
             <title>{{ bar.label }}: {{ bar.total }} trigger{{ bar.total === 1 ? '' : 's' }}</title>
           </g>
         </svg>
-        <div class="chart-labels">
+        <div class="relative h-5 mt-1">
           <span v-for="(bar, i) in chartData" :key="bar.date"
             :style="{ left: ((i + 0.5) * (100 / chartData.length)) + '%' }"
-            class="chart-label"
+            class="absolute -translate-x-1/2 text-[11px] text-text-secondary whitespace-nowrap"
             v-show="chartPeriod === 7 || i % 5 === 0 || i === chartData.length - 1"
           >{{ bar.label }}</span>
         </div>
@@ -110,400 +110,73 @@ function timeAgo(ts: number): string {
     </div>
 
     <!-- Most used shortcuts -->
-    <div class="analytics-section" v-if="mostUsed.length > 0">
-      <h3 class="section-title">Most used shortcuts</h3>
-      <div class="analytics-table">
-        <div class="table-row table-header">
-          <span class="col-rank">#</span>
-          <span class="col-shortcut">Shortcut</span>
-          <span class="col-key">Key</span>
-          <span class="col-count">Uses</span>
-          <span class="col-last">Last used</span>
+    <div class="mb-8" v-if="mostUsed.length > 0">
+      <h3 class="text-base font-bold text-text-primary mb-3">Most used shortcuts</h3>
+      <div class="bg-surface-elevated border border-border-light rounded-[14px] overflow-hidden shadow-sm">
+        <div class="flex items-center px-4 py-2 bg-surface-elevated text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+          <span class="w-8 text-center">#</span>
+          <span class="flex-1 min-w-0">Shortcut</span>
+          <span class="w-[140px] shrink-0">Key</span>
+          <span class="w-16 text-center shrink-0">Uses</span>
+          <span class="w-[100px] shrink-0 text-right">Last used</span>
         </div>
-        <div v-for="(item, i) in mostUsed" :key="item.id" class="table-row">
-          <span class="col-rank">{{ i + 1 }}</span>
-          <span class="col-shortcut">{{ item.label }}</span>
-          <span class="col-key">
-            <kbd v-for="part in item.key.split('+')" :key="part" class="key-badge">{{ part }}</kbd>
+        <div v-for="(item, i) in mostUsed" :key="item.id" class="flex items-center px-5 py-3 gap-3 border-t border-border-light transition-colors duration-150 hover:bg-surface-hover">
+          <span class="w-8 text-center text-text-muted font-semibold text-[13px]">{{ i + 1 }}</span>
+          <span class="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-[13px] text-text-primary">{{ item.label }}</span>
+          <span class="w-[140px] shrink-0 flex gap-0.5 flex-wrap">
+            <kbd v-for="part in item.key.split('+')" :key="part" class="inline-block px-2 py-0.5 bg-surface-hover border border-border-default rounded-md font-mono text-[11px] text-text-secondary capitalize">{{ part }}</kbd>
           </span>
-          <span class="col-count">
-            <span class="count-badge">{{ item.count }}</span>
+          <span class="w-16 text-center shrink-0">
+            <span class="inline-block px-3 py-0.5 bg-accent-bg text-accent rounded-full text-xs font-semibold">{{ item.count }}</span>
           </span>
-          <span class="col-last">{{ timeAgo(item.lastUsed) }}</span>
+          <span class="w-[100px] shrink-0 text-xs text-text-muted text-right">{{ timeAgo(item.lastUsed) }}</span>
         </div>
       </div>
     </div>
 
     <!-- Recently used -->
-    <div class="analytics-section" v-if="recentlyUsed.length > 0">
-      <h3 class="section-title">Recently used</h3>
-      <div class="analytics-table">
-        <div class="table-row table-header">
-          <span class="col-shortcut">Shortcut</span>
-          <span class="col-key">Key</span>
-          <span class="col-last">When</span>
+    <div class="mb-8" v-if="recentlyUsed.length > 0">
+      <h3 class="text-base font-bold text-text-primary mb-3">Recently used</h3>
+      <div class="bg-surface-elevated border border-border-light rounded-[14px] overflow-hidden shadow-sm">
+        <div class="flex items-center px-4 py-2 bg-surface-elevated text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+          <span class="flex-1 min-w-0">Shortcut</span>
+          <span class="w-[140px] shrink-0">Key</span>
+          <span class="w-[100px] shrink-0 text-right">When</span>
         </div>
-        <div v-for="item in recentlyUsed" :key="item.id" class="table-row">
-          <span class="col-shortcut">{{ item.label }}</span>
-          <span class="col-key">
-            <kbd v-for="part in item.key.split('+')" :key="part" class="key-badge">{{ part }}</kbd>
+        <div v-for="item in recentlyUsed" :key="item.id" class="flex items-center px-5 py-3 gap-3 border-t border-border-light transition-colors duration-150 hover:bg-surface-hover">
+          <span class="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-[13px] text-text-primary">{{ item.label }}</span>
+          <span class="w-[140px] shrink-0 flex gap-0.5 flex-wrap">
+            <kbd v-for="part in item.key.split('+')" :key="part" class="inline-block px-2 py-0.5 bg-surface-hover border border-border-default rounded-md font-mono text-[11px] text-text-secondary capitalize">{{ part }}</kbd>
           </span>
-          <span class="col-last">{{ timeAgo(item.lastUsed) }}</span>
+          <span class="w-[100px] shrink-0 text-xs text-text-muted text-right">{{ timeAgo(item.lastUsed) }}</span>
         </div>
       </div>
     </div>
 
     <!-- Unused shortcuts -->
-    <div class="analytics-section" v-if="unusedShortcuts.length > 0">
-      <h3 class="section-title">Never used</h3>
-      <p class="tab-desc">These shortcuts have never been triggered. Consider removing them or adjusting their key bindings.</p>
-      <div class="unused-list">
-        <div v-for="item in unusedShortcuts" :key="item.id" class="unused-item">
-          <span class="unused-label">{{ item.label }}</span>
-          <span class="unused-key">
-            <kbd v-for="part in item.key.split('+')" :key="part" class="key-badge">{{ part }}</kbd>
+    <div class="mb-8" v-if="unusedShortcuts.length > 0">
+      <h3 class="text-base font-bold text-text-primary mb-3">Never used</h3>
+      <p class="text-text-secondary mb-3">These shortcuts have never been triggered. Consider removing them or adjusting their key bindings.</p>
+      <div class="flex flex-col gap-1">
+        <div v-for="item in unusedShortcuts" :key="item.id" class="flex justify-between items-center px-4 py-2 bg-surface-elevated border border-border-light rounded-xl gap-3">
+          <span class="text-[13px] text-text-secondary overflow-hidden text-ellipsis whitespace-nowrap flex-1 min-w-0">{{ item.label }}</span>
+          <span class="flex gap-0.5 shrink-0">
+            <kbd v-for="part in item.key.split('+')" :key="part" class="inline-block px-2 py-0.5 bg-surface-hover border border-border-default rounded-md font-mono text-[11px] text-text-secondary capitalize">{{ part }}</kbd>
           </span>
         </div>
       </div>
     </div>
 
     <!-- Empty state -->
-    <div v-if="totalUsage === 0 && unusedShortcuts.length === 0" class="analytics-empty">
+    <div v-if="totalUsage === 0 && unusedShortcuts.length === 0" class="text-center py-12 text-text-muted">
       <i class="mdi mdi-chart-line" style="font-size: 48px; color: var(--text-muted)"></i>
-      <p>No shortcuts configured yet.</p>
-      <p class="tab-desc">Add some shortcuts in the Shortcuts tab, then use them to see analytics here.</p>
+      <p class="mt-2 text-sm">No shortcuts configured yet.</p>
+      <p class="text-text-secondary text-sm">Add some shortcuts in the Shortcuts tab, then use them to see analytics here.</p>
     </div>
 
-    <p class="analytics-privacy">
-      <i class="mdi mdi-shield-check-outline"></i>
+    <p class="flex items-center gap-1.5 text-xs text-text-muted mt-4 px-4 py-3 bg-surface-elevated rounded-xl border border-border-light shadow-sm">
+      <i class="mdi mdi-shield-check-outline text-base text-success"></i>
       All analytics data is stored locally on this device and never sent anywhere.
     </p>
   </div>
 </template>
-
-<style scoped>
-.analytics-loading {
-  text-align: center;
-  padding: var(--space-3xl) 0;
-  color: var(--text-muted);
-  font-size: 14px;
-}
-
-.analytics-loading .mdi { margin-right: 6px; }
-
-.analytics-header {
-display: flex;
-justify-content: space-between;
-align-items: center;
-gap: var(--space-lg);
-margin-bottom: var(--space-xl);
-flex-wrap: wrap;
-}
-
-.analytics-summary {
-display: flex;
-gap: var(--space-2xl);
-}
-
-.summary-stat {
-display: flex;
-flex-direction: column;
-  gap: 4px;
-  position: relative;
-}
-
-.summary-stat:not(:last-child)::after {
-  content: '';
-  position: absolute;
-  right: calc(var(--space-2xl) / -2);
-  top: 10%;
-  height: 80%;
-  width: 1px;
-  background: var(--border);
-  opacity: 0.5;
-}
-
-.summary-number {
-  font-size: 36px;
-  font-weight: 700;
-  color: var(--text);
-  line-height: 1;
-  letter-spacing: -0.02em;
-}
-
-.summary-label {
-  font-size: 13px;
-  color: var(--text-muted);
-  font-weight: 500;
-}
-
-.analytics-actions {
-display: flex;
-align-items: center;
-gap: var(--space-lg);
-}
-
-.toggle-label {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  font-size: 14px;
-  color: var(--text-secondary);
-  cursor: pointer;
-  user-select: none;
-}
-
-.toggle-label input[type="checkbox"] {
-  width: 16px;
-  height: 16px;
-  accent-color: var(--blue);
-  cursor: pointer;
-}
-
-.btn-clear {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 6px 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--bg-elevated);
-  color: var(--text-secondary);
-  font-size: 13px;
-  cursor: pointer;
-  white-space: nowrap;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.btn-clear:hover {
-  background: var(--bg-hover);
-  color: var(--danger, #ef4444);
-  border-color: var(--danger, #ef4444);
-}
-
-.btn-clear .mdi {
-  font-size: 15px;
-}
-
-.analytics-section {
-margin-bottom: var(--space-xl);
-}
-
-.section-header {
-display: flex;
-justify-content: space-between;
-align-items: center;
-margin-bottom: var(--space-md);
-}
-
-.section-header .section-title {
-  margin-bottom: 0;
-}
-
-.section-title {
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--text);
-  margin-bottom: var(--space-md);
-  letter-spacing: -0.01em;
-}
-
-.chart-period-toggle {
-  display: flex;
-  gap: 2px;
-  background: var(--bg-elevated);
-  border-radius: var(--radius-lg);
-  padding: 2px;
-  border: 1px solid var(--border-light);
-}
-
-.period-btn {
-  padding: 4px 12px;
-  border: none;
-  border-radius: var(--radius-md);
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.period-btn:hover { color: var(--text); }
-
-.period-btn.active {
-  background: var(--blue);
-  color: white;
-  box-shadow: var(--shadow-sm);
-}
-
-.chart-container {
-  position: relative;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius-2xl);
-  padding: 20px 20px var(--space-xl);
-}
-
-.usage-chart {
-  width: 100%;
-  height: 160px;
-}
-
-.chart-grid {
-  stroke: var(--border-light);
-  stroke-width: 1;
-  stroke-dasharray: 4 4;
-}
-
-.chart-bar {
-  fill: var(--blue);
-  opacity: 0.85;
-  transition: opacity 0.2s cubic-bezier(0.16, 1, 0.3, 1), filter 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.chart-bar:hover {
-  opacity: 1;
-  filter: brightness(1.1);
-}
-
-.chart-labels {
-  position: relative;
-  height: 20px;
-  margin-top: 4px;
-}
-
-.chart-label {
-  position: absolute;
-  transform: translateX(-50%);
-  font-size: 11px;
-  color: var(--text-secondary);
-  white-space: nowrap;
-}
-
-
-.analytics-table {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius-2xl);
-  overflow: hidden;
-  box-shadow: var(--shadow-sm);
-  transition: box-shadow 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.table-row {
-  display: flex;
-  align-items: center;
-  padding: 12px 20px;
-  gap: var(--space-md);
-  border-bottom: 1px solid var(--border-light);
-  transition: background 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.table-row:last-child { border-bottom: none; }
-
-.table-row:not(.table-header):hover {
-  background: var(--bg-hover);
-}
-
-.table-header {
-  background: var(--bg-elevated);
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.8px;
-  padding: 8px 16px;
-}
-
-.col-rank { width: 32px; text-align: center; color: var(--text-muted); font-weight: 600; font-size: 13px; }
-.col-shortcut { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; color: var(--text); }
-.col-key { width: 140px; flex-shrink: 0; display: flex; gap: 3px; flex-wrap: wrap; }
-.col-count { width: 64px; text-align: center; flex-shrink: 0; }
-.col-last { width: 100px; flex-shrink: 0; font-size: 12px; color: var(--text-muted); text-align: right; }
-
-.key-badge {
-  display: inline-block;
-  padding: 2px 8px;
-  background: var(--bg-hover);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  font-size: 11px;
-  font-family: 'SF Mono', Menlo, monospace;
-  color: var(--text-secondary);
-  text-transform: capitalize;
-}
-
-.count-badge {
-  display: inline-block;
-  padding: 3px 12px;
-  background: var(--blue-bg);
-  color: var(--blue);
-  border-radius: var(--radius-full);
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.unused-list {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.unused-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 8px 16px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius-xl);
-  gap: var(--space-md);
-}
-
-.unused-label {
-  font-size: 13px;
-  color: var(--text-secondary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex: 1;
-  min-width: 0;
-}
-
-.unused-key {
-  display: flex;
-  gap: 3px;
-  flex-shrink: 0;
-}
-
-.analytics-empty {
-  text-align: center;
-  padding: var(--space-3xl) 0;
-  color: var(--text-muted);
-}
-
-.analytics-empty p {
-  margin: 8px 0 0;
-  font-size: 14px;
-}
-
-.analytics-privacy {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  font-size: 12px;
-  color: var(--text-muted);
-  margin-top: 16px;
-  padding: 12px 16px;
-  background: var(--bg-elevated);
-  border-radius: var(--radius-xl);
-  border: 1px solid var(--border-light);
-  box-shadow: var(--shadow-sm);
-}
-
-.analytics-privacy .mdi {
-font-size: 16px;
-color: var(--success);
-}
-</style>

--- a/src/components/CodeEditor.vue
+++ b/src/components/CodeEditor.vue
@@ -67,26 +67,10 @@ watch(
 </script>
 
 <template>
-  <div ref="editorEl" class="cm-wrap"></div>
+  <div ref="editorEl" class="cm-wrap rounded-none border-none overflow-hidden transition-[border-color,box-shadow] duration-150 focus-within:shadow-md focus-within:border-accent"></div>
 </template>
 
 <style scoped>
-.cm-wrap {
-  border-radius: 0;
-  border: none;
-  overflow: hidden;
-  transition: border-color 0.15s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.15s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.cm-wrap:focus-within {
-  box-shadow: var(--shadow-md);
-  border-color: var(--blue, #4f46e5);
-}
-
-.cm-wrap :deep(.cm-editor) {
-  min-height: 200px;
-}
-
-.cm-wrap :deep(.cm-editor.cm-focused) {
-  outline: none;
-}
+.cm-wrap :deep(.cm-editor) { min-height: 200px; }
+.cm-wrap :deep(.cm-editor.cm-focused) { outline: none; }
 </style>

--- a/src/components/CommunityPackModal.vue
+++ b/src/components/CommunityPackModal.vue
@@ -32,76 +32,76 @@ const keyConflictCount = computed(() => {
 
 <template>
   <Transition name="modal">
-    <div v-if="previewCommunityPack" class="modal-overlay" @click.self="previewCommunityPack = null">
-      <div class="modal-panel">
-        <div class="modal-header" :style="{ background: previewCommunityPack.color }">
-          <span class="modal-icon">{{ previewCommunityPack.icon }}</span>
+    <div v-if="previewCommunityPack" class="fixed inset-0 z-[100] bg-black/30 backdrop-blur-[16px] flex items-center justify-center p-6" @click.self="previewCommunityPack = null">
+      <div class="modal-panel bg-surface-card rounded-3xl w-full max-w-[580px] max-h-[85vh] flex flex-col overflow-hidden shadow-xl border border-border-light">
+        <div class="flex items-center gap-4 px-8 py-6 text-white relative" :style="{ background: previewCommunityPack.color }">
+          <span class="text-4xl shrink-0">{{ previewCommunityPack.icon }}</span>
           <div>
-            <h2 class="modal-title">{{ previewCommunityPack.name }}</h2>
-            <p class="modal-subtitle">{{ previewCommunityPack.description }}</p>
-            <div class="modal-author-badge">
+            <h2 class="text-lg font-bold m-0">{{ previewCommunityPack.name }}</h2>
+            <p class="text-[13px] opacity-85 mt-1 m-0">{{ previewCommunityPack.description }}</p>
+            <div class="flex items-center gap-2 mt-2 text-[13px] opacity-90">
               <i class="mdi mdi-account"></i> {{ previewCommunityPack.author }}
-              <span class="community-badge">Community</span>
+              <span class="bg-white/25 px-1.5 py-0.5 rounded-[5px] text-[10px] uppercase tracking-wider font-semibold">Community</span>
             </div>
           </div>
-          <button class="modal-close" @click="previewCommunityPack = null" type="button">
+          <button class="absolute top-3 right-3 bg-white/20 border-none text-white w-7 h-7 rounded-full flex items-center justify-center cursor-pointer text-base transition-colors duration-150 hover:bg-white/35" @click="previewCommunityPack = null" type="button">
             <i class="mdi mdi-close"></i>
           </button>
         </div>
-        <div class="modal-body">
-          <div v-if="previewCommunityPack.hasJavaScript" class="modal-js-warning">
-            <i class="mdi mdi-alert-outline"></i>
+        <div class="px-8 py-6 overflow-y-auto flex-1">
+          <div v-if="previewCommunityPack.hasJavaScript" class="flex items-center gap-2 px-4.5 py-3 bg-warning-bg border border-warning-border text-warning-text rounded-[14px] mb-4 text-[13px] font-medium">
+            <i class="mdi mdi-alert-outline text-lg"></i>
             This pack contains custom JavaScript. Only install if you trust the author.
           </div>
 
-          <div class="modal-shortcuts">
+          <div class="flex flex-col gap-0.5">
             <div
               v-for="(s, si) in previewCommunityPack.shortcuts"
               :key="s.key"
-              class="modal-shortcut-row"
+              class="flex justify-between items-center px-4 py-3 rounded-[10px] gap-3 transition-colors duration-200 odd:bg-surface-elevated hover:bg-surface-hover"
               :class="{
-                'modal-shortcut-conflict': conflicts.has(si) && conflicts.get(si)!.type === 'key',
-                'modal-shortcut-exact': conflicts.has(si) && conflicts.get(si)!.type === 'exact',
+                'bg-warning-bg border-l-[3px] border-l-warning-border pl-[9px] rounded-l-lg transition-all duration-400': conflicts.has(si) && conflicts.get(si)!.type === 'key',
+                'bg-info-bg border-l-[3px] border-l-text-muted pl-[9px] opacity-60 rounded-l-lg transition-all duration-400': conflicts.has(si) && conflicts.get(si)!.type === 'exact',
               }"
             >
-              <span class="modal-shortcut-label">
+              <span class="text-[13px] text-text-primary">
                 {{ s.label || s.action }}
-                <span v-if="conflicts.has(si) && conflicts.get(si)!.type === 'exact'" class="conflict-badge exact">duplicate</span>
-                <span v-else-if="conflicts.has(si)" class="conflict-badge key">conflict</span>
+                <span v-if="conflicts.has(si) && conflicts.get(si)!.type === 'exact'" class="inline-block text-[10px] px-[7px] py-[2px] rounded-lg ml-1.5 font-semibold uppercase tracking-wider align-middle transition-all duration-400 bg-surface-hover text-text-secondary">duplicate</span>
+                <span v-else-if="conflicts.has(si)" class="inline-block text-[10px] px-[7px] py-[2px] rounded-lg ml-1.5 font-semibold uppercase tracking-wider align-middle transition-all duration-400 bg-warning-bg text-warning-text">conflict</span>
               </span>
-              <span class="modal-shortcut-keys">
-                <kbd v-for="(part, pi) in s.key.split('+')" :key="pi">{{ part }}</kbd>
+              <span class="flex gap-[3px] shrink-0">
+                <kbd v-for="(part, pi) in s.key.split('+')" :key="pi" class="inline-block px-[7px] py-[2px] bg-surface-hover border border-border-default rounded-[5px] font-mono text-[11px] text-text-secondary capitalize">{{ part }}</kbd>
               </span>
             </div>
           </div>
 
-          <div v-if="communityExactDuplicateCount > 0" class="modal-exact-notice">
+          <div v-if="communityExactDuplicateCount > 0" class="flex items-center gap-2 px-4 py-3 bg-info-bg border border-info-border text-info-text rounded-[14px] mt-3 text-[13px] font-medium shadow-sm transition-all duration-400">
             <i class="mdi mdi-information-outline"></i>
             {{ communityExactDuplicateCount }} exact duplicate{{ communityExactDuplicateCount > 1 ? 's' : '' }} will be skipped automatically (same key and action already exist)
           </div>
 
-          <div v-if="keyConflictCount > 0" class="modal-conflicts">
-            <div class="modal-conflict-header">
+          <div v-if="keyConflictCount > 0" class="mt-4 px-4 py-3 bg-warning-bg border border-warning-border rounded-[10px]">
+            <div class="text-[13px] font-semibold text-warning-text mb-2.5 flex items-center gap-1.5">
               <i class="mdi mdi-alert-outline"></i>
               {{ keyConflictCount }} shortcut{{ keyConflictCount > 1 ? 's' : '' }} conflict with your existing shortcuts
             </div>
-            <div class="modal-conflict-options">
-              <label class="radio-option">
+            <div class="flex flex-col gap-2">
+              <label class="flex items-center gap-2 text-[13px] text-text-secondary cursor-pointer">
                 <input type="radio" v-model="communityConflictMode" value="replace" />
                 <span>Replace my shortcuts with pack versions</span>
               </label>
-              <label class="radio-option">
+              <label class="flex items-center gap-2 text-[13px] text-text-secondary cursor-pointer">
                 <input type="radio" v-model="communityConflictMode" value="skip" />
                 <span>Skip conflicting shortcuts</span>
               </label>
-              <label class="radio-option">
+              <label class="flex items-center gap-2 text-[13px] text-text-secondary cursor-pointer">
                 <input type="radio" v-model="communityConflictMode" value="keep" />
                 <span>Keep both (I'll sort it out later)</span>
               </label>
             </div>
           </div>
         </div>
-        <div class="modal-footer">
+        <div class="flex justify-end gap-3 px-8 py-5 border-t border-border-default bg-surface-elevated">
           <button class="btn btn-secondary" @click="previewCommunityPack = null" type="button">Cancel</button>
           <button class="btn btn-primary" @click="requestInstallCommunityPack(previewCommunityPack)" type="button">
             <i class="mdi mdi-plus"></i> Add {{ addCount }} shortcut{{ addCount !== 1 ? 's' : '' }}
@@ -111,91 +111,3 @@ const keyConflictCount = computed(() => {
     </div>
   </Transition>
 </template>
-
-<style scoped>
-.modal-author-badge {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 8px;
-  font-size: 13px;
-  opacity: 0.9;
-}
-.community-badge {
-  background: rgba(255, 255, 255, 0.25);
-  padding: 2px 6px;
-  border-radius: var(--radius-sm);
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  font-weight: 600;
-}
-.modal-js-warning {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 12px 18px;
-  background: var(--warning-bg);
-  border: 1px solid var(--warning-border);
-  color: var(--warning-text);
-  border-radius: var(--radius-xl);
-  margin-bottom: 16px;
-  font-size: 13px;
-  font-weight: 500;
-}
-.modal-js-warning .mdi {
-  font-size: 18px;
-}
-.modal-shortcut-conflict {
-  background: var(--warning-bg);
-  border-left: 3px solid var(--warning-border);
-  padding-left: 9px;
-  border-top-left-radius: var(--radius-md);
-  border-bottom-left-radius: var(--radius-md);
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.modal-shortcut-exact {
-  background: var(--info-bg);
-  border-left: 3px solid var(--text-muted);
-  padding-left: 9px;
-  opacity: 0.6;
-  border-top-left-radius: var(--radius-md);
-  border-bottom-left-radius: var(--radius-md);
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.conflict-badge {
-  display: inline-block;
-  font-size: 10px;
-  padding: 2px 7px;
-  border-radius: var(--radius-md);
-  margin-left: 6px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-  vertical-align: middle;
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.conflict-badge.key {
-  background: var(--warning-bg);
-  color: var(--warning-text);
-}
-.conflict-badge.exact {
-  background: var(--bg-hover);
-  color: var(--text-secondary);
-}
-.modal-exact-notice {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 12px 16px;
-  background: var(--info-bg);
-  border: 1px solid var(--info-border);
-  color: var(--info-text);
-  border-radius: var(--radius-xl);
-  margin-top: 12px;
-  font-size: 13px;
-  font-weight: 500;
-  box-shadow: var(--shadow-sm);
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-</style>

--- a/src/components/ExportTab.vue
+++ b/src/components/ExportTab.vue
@@ -7,20 +7,20 @@ const { shareLink, copyExport, generateShareLink } = useImportExport()
 </script>
 
 <template>
-  <div class="export-header">
-    <p class="tab-desc">Copy the JSON below to back up or share your shortcuts.</p>
-    <div class="export-actions">
-      <button class="btn btn-secondary" @click="copyExport">
+  <div class="flex justify-between items-center mb-3">
+    <p class="text-text-secondary mb-0">Copy the JSON below to back up or share your shortcuts.</p>
+    <div class="flex gap-2">
+      <button class="px-4 py-2 border-none rounded-lg text-[13px] font-semibold cursor-pointer transition-all duration-200 inline-flex items-center gap-1.5 bg-surface-card text-text-secondary border border-border-default hover:bg-surface-hover hover:text-text-primary !px-3 !py-1 !text-xs" @click="copyExport">
         <i class="mdi mdi-content-copy"></i> Copy JSON
       </button>
-      <button class="btn btn-primary" @click="generateShareLink">
+      <button class="px-4 py-2 border-none rounded-lg text-[13px] font-semibold cursor-pointer transition-all duration-200 inline-flex items-center gap-1.5 bg-accent text-white shadow-[0_1px_3px_var(--blue-bg)] hover:bg-accent-hover !px-3 !py-1 !text-xs" @click="generateShareLink">
         <i class="mdi mdi-share-variant"></i> Share Link
       </button>
     </div>
   </div>
-  <div v-if="shareLink" class="share-link-box">
-    <input class="field-input mono" :value="shareLink" readonly @click="($event.target as HTMLInputElement).select()" />
-    <p class="share-hint">Anyone with Shortkeys can import your shortcuts from this link.</p>
+  <div v-if="shareLink" class="mb-3 p-3 px-4 bg-info-bg border border-info-border rounded-[10px]">
+    <input class="w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)] font-mono" :value="shareLink" readonly @click="($event.target as HTMLInputElement).select()" />
+    <p class="text-xs text-accent mt-2 mb-0">Anyone with Shortkeys can import your shortcuts from this link.</p>
   </div>
-  <pre class="export-pre">{{ JSON.stringify(keys, null, 2) }}</pre>
+  <pre class="bg-surface-card border border-border-default rounded-[10px] p-4 font-mono text-xs overflow-auto max-h-[500px] text-text-primary">{{ JSON.stringify(keys, null, 2) }}</pre>
 </template>

--- a/src/components/ImportTab.vue
+++ b/src/components/ImportTab.vue
@@ -5,16 +5,16 @@ const { importJson, importKeys } = useImportExport()
 </script>
 
 <template>
-  <div class="import-tab-container">
+  <div class="flex flex-col gap-10">
     <!-- JSON Import -->
-    <div class="import-section json-section">
-      <div class="section-header">
-        <h3 class="section-title">Import JSON</h3>
-        <p class="tab-desc">Paste a JSON array of shortcut objects to import them.</p>
+    <div>
+      <div class="mb-4">
+        <h3 class="text-base font-bold text-text-primary mb-1">Import JSON</h3>
+        <p class="text-text-secondary mb-3">Paste a JSON array of shortcut objects to import them.</p>
       </div>
       
-      <div class="json-import-card">
-        <textarea class="field-textarea mono json-textarea" v-model="importJson" rows="8" placeholder='[
+      <div class="bg-surface-card border border-border-default rounded-[14px] p-5 shadow-sm">
+        <textarea class="w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)] resize-y font-mono min-h-40 text-[13px] leading-relaxed" v-model="importJson" rows="8" placeholder='[
   {
     "key": "ctrl+shift+y",
     "action": "javascript",
@@ -22,9 +22,9 @@ const { importJson, importKeys } = useImportExport()
     "code": "alert(document.title);"
   }
 ]'></textarea>
-        <div class="action-bar json-action-bar">
-          <span class="json-hint"><i class="mdi mdi-code-json"></i> Valid JSON required</span>
-          <button class="btn btn-primary" @click="importKeys">
+        <div class="mt-4 pt-4 border-t border-dashed border-border-light flex justify-between items-center">
+          <span class="text-[13px] text-text-muted flex items-center gap-1.5"><i class="mdi mdi-code-json"></i> Valid JSON required</span>
+          <button class="px-4 py-2 border-none rounded-lg text-[13px] font-semibold cursor-pointer transition-all duration-200 inline-flex items-center gap-1.5 bg-accent text-white shadow-[0_1px_3px_var(--blue-bg)] hover:bg-accent-hover" @click="importKeys">
             <i class="mdi mdi-import"></i> Import JSON
           </button>
         </div>

--- a/src/components/JsWarningDialog.vue
+++ b/src/components/JsWarningDialog.vue
@@ -12,29 +12,29 @@ const jsShortcutCount = computed(() => {
 
 <template>
   <Transition name="modal">
-    <div v-if="jsWarningPack" class="modal-overlay" @click.self="dismissJsWarning">
-      <div class="modal-panel warning-panel">
-        <div class="modal-header warning-header">
-          <span class="modal-icon"><i class="mdi mdi-alert"></i></span>
+    <div v-if="jsWarningPack" class="fixed inset-0 z-[100] bg-black/30 backdrop-blur-[16px] flex items-center justify-center p-6" @click.self="dismissJsWarning">
+      <div class="modal-panel bg-surface-card rounded-3xl w-full max-w-[580px] max-h-[85vh] flex flex-col overflow-hidden shadow-xl border border-border-light !max-w-[520px] !rounded-[14px]">
+        <div class="flex items-center gap-4 px-8 py-6 text-white relative !bg-[#f59e0b] shadow-[0_4px_12px_rgba(245,158,11,0.25)]">
+          <span class="text-4xl shrink-0"><i class="mdi mdi-alert"></i></span>
           <div>
-            <h2 class="modal-title">Security Warning</h2>
-            <p class="modal-subtitle">Custom JavaScript detected</p>
+            <h2 class="text-lg font-bold m-0">Security Warning</h2>
+            <p class="text-[13px] opacity-85 mt-1 m-0">Custom JavaScript detected</p>
           </div>
-          <button class="modal-close" @click="dismissJsWarning" type="button">
+          <button class="absolute top-3 right-3 bg-white/20 border-none text-white w-7 h-7 rounded-full flex items-center justify-center cursor-pointer text-base transition-colors duration-150 hover:bg-white/35" @click="dismissJsWarning" type="button">
             <i class="mdi mdi-close"></i>
           </button>
         </div>
-        <div class="modal-body">
-          <p class="warning-text">
+        <div class="px-8 py-6 overflow-y-auto flex-1">
+          <p class="text-sm leading-relaxed mb-3 text-text-primary last:mb-0">
             This community pack (<strong>{{ jsWarningPack.name }}</strong> by {{ jsWarningPack.author }}) contains <strong>{{ jsShortcutCount }} custom JavaScript shortcut{{ jsShortcutCount !== 1 ? 's' : '' }}</strong> that will run on web pages you visit.
           </p>
-          <p class="warning-text">
+          <p class="text-sm leading-relaxed mb-3 text-text-primary last:mb-0">
             Only install packs from authors you trust. Malicious code could potentially access your personal data on websites.
           </p>
         </div>
-        <div class="modal-footer">
+        <div class="flex justify-end gap-3 px-8 py-5 border-t border-border-default bg-surface-elevated">
           <button class="btn btn-secondary" @click="dismissJsWarning" type="button">Cancel</button>
-          <button class="btn btn-warning" @click="confirmJsInstall" type="button">
+          <button class="btn bg-danger text-white transition-all duration-200 font-semibold px-5 py-2.5 hover:bg-danger-hover hover:-translate-y-px hover:shadow-md" @click="confirmJsInstall" type="button">
             Install anyway
           </button>
         </div>
@@ -42,35 +42,3 @@ const jsShortcutCount = computed(() => {
     </div>
   </Transition>
 </template>
-
-<style scoped>
-.warning-panel {
-  max-width: 520px;
-  border-radius: var(--radius-xl);
-}
-.warning-header {
-  background: #f59e0b;
-  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.25);
-}
-.warning-text {
-  font-size: 14px;
-  line-height: 1.6;
-  margin: 0 0 12px;
-  color: var(--text);
-}
-.warning-text:last-child {
-  margin-bottom: 0;
-}
-.btn-warning {
-  background: var(--danger);
-  color: #fff;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-  font-weight: 600;
-  padding: 10px 20px;
-}
-.btn-warning:hover {
-  background: var(--danger-hover);
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-md);
-}
-</style>

--- a/src/components/OnboardingWizard.vue
+++ b/src/components/OnboardingWizard.vue
@@ -224,80 +224,80 @@ const skip = () => {
 }
 </script>
 <template>
-  <div class="onboarding-wizard">
-    <div class="wizard-header">
-      <div class="step-indicator">
-        <div :class="['step-dot', { active: step >= 1, current: step === 1 }]">1</div>
-        <div class="step-label" :class="{ active: step >= 1 }">Choose actions</div>
-        <div :class="['step-line', { active: step >= 2 }]"></div>
-        <div :class="['step-dot', { active: step >= 2, current: step === 2 }]">2</div>
-        <div class="step-label" :class="{ active: step >= 2 }">Set up shortcuts</div>
-        <div :class="['step-line', { active: step >= 3 }]"></div>
-        <div :class="['step-dot', { active: step >= 3, current: step === 3 }]">3</div>
-        <div class="step-label" :class="{ active: step >= 3 }">All set!</div>
+  <div class="bg-surface-card border border-border-default rounded-[18px] shadow-xl max-w-[680px] mx-auto my-10 flex flex-col">
+    <div class="px-8 pt-8 pb-0 flex flex-col items-center gap-4">
+      <div class="flex items-center gap-2">
+        <div :class="['w-8 h-8 rounded-full bg-surface-elevated border-2 border-border-default text-text-muted flex items-center justify-center text-[13px] font-bold transition-all duration-400', { '!bg-accent-bg !border-accent !text-accent': step >= 1, '!bg-accent !text-white shadow-[0_0_0_6px_var(--blue-bg)]': step === 1 }]">1</div>
+        <div :class="['text-[13px] font-semibold text-text-muted transition-colors duration-400', { '!text-text-primary': step >= 1 }]">Choose actions</div>
+        <div :class="['w-10 h-[2px] bg-border-default transition-all duration-400', { '!bg-accent': step >= 2 }]"></div>
+        <div :class="['w-8 h-8 rounded-full bg-surface-elevated border-2 border-border-default text-text-muted flex items-center justify-center text-[13px] font-bold transition-all duration-400', { '!bg-accent-bg !border-accent !text-accent': step >= 2, '!bg-accent !text-white shadow-[0_0_0_6px_var(--blue-bg)]': step === 2 }]">2</div>
+        <div :class="['text-[13px] font-semibold text-text-muted transition-colors duration-400', { '!text-text-primary': step >= 2 }]">Set up shortcuts</div>
+        <div :class="['w-10 h-[2px] bg-border-default transition-all duration-400', { '!bg-accent': step >= 3 }]"></div>
+        <div :class="['w-8 h-8 rounded-full bg-surface-elevated border-2 border-border-default text-text-muted flex items-center justify-center text-[13px] font-bold transition-all duration-400', { '!bg-accent-bg !border-accent !text-accent': step >= 3, '!bg-accent !text-white shadow-[0_0_0_6px_var(--blue-bg)]': step === 3 }]">3</div>
+        <div :class="['text-[13px] font-semibold text-text-muted transition-colors duration-400', { '!text-text-primary': step >= 3 }]">All set!</div>
       </div>
-      <button v-if="step < 3" class="btn-skip-top" @click="skip" type="button">
+      <button v-if="step < 3" class="text-[13px] text-text-secondary font-semibold bg-transparent border border-border-default px-4 py-2 rounded-[14px] cursor-pointer transition-all duration-200 inline-flex items-center gap-1.5 hover:bg-surface-elevated hover:text-text-primary" @click="skip" type="button">
         Skip — I'll set up my own <i class="mdi mdi-arrow-right"></i>
       </button>
     </div>
 
-    <div class="wizard-content">
+    <div class="px-12 py-8 min-h-[360px] flex flex-col">
       <Transition name="fade" mode="out-in">
         <!-- Step 1: Choose actions -->
-        <div v-if="step === 1" class="step-panel">
-          <h2 class="step-title">Quick start</h2>
-          <p class="step-desc">Pick a few actions below, then assign shortcuts. You can always change these later.</p>
+        <div v-if="step === 1" class="flex flex-col flex-1 animate-[slideUp_0.3s_cubic-bezier(0.16,1,0.3,1)]">
+          <h2 class="text-xl font-bold text-text-primary mb-2 tracking-tight text-center">Quick start</h2>
+          <p class="text-[15px] text-text-secondary mb-6 leading-relaxed text-center">Pick a few actions below, then assign shortcuts. You can always change these later.</p>
           
-          <div class="action-grid">
+          <div class="grid grid-cols-3 gap-3 mb-8">
             <button 
               v-for="action in visibleActions" 
               :key="action.id"
-              :class="['action-card', { 'selected': selectedActions.includes(action.id) }]"
+              :class="['flex flex-col gap-3 p-5 bg-surface-elevated border border-border-default rounded-[18px] cursor-pointer transition-all duration-200 text-left hover:bg-surface-hover hover:-translate-y-[3px] hover:shadow-lg', { '!bg-accent-bg !border-accent shadow-[inset_0_2px_8px_rgba(0,0,0,0.05)]': selectedActions.includes(action.id) }]"
               @click="toggleAction(action.id)"
               type="button"
             >
-              <div class="action-card-header">
-                <i :class="['mdi', action.icon, 'action-icon']"></i>
-                <div class="checkbox-indicator">
-                  <i v-if="selectedActions.includes(action.id)" class="mdi mdi-check"></i>
+              <div class="flex justify-between items-start w-full">
+                <i :class="['mdi', action.icon, 'text-[32px] text-text-secondary opacity-90 transition-all duration-200', { '!text-accent': selectedActions.includes(action.id) }]"></i>
+                <div :class="['w-5 h-5 rounded-[10px] border-2 border-border-light bg-surface-card flex items-center justify-center transition-all duration-200', { '!bg-accent !border-accent !text-white': selectedActions.includes(action.id) }]">
+                  <i v-if="selectedActions.includes(action.id)" class="mdi mdi-check text-sm font-bold"></i>
                 </div>
               </div>
-              <span class="action-label">{{ action.label }}</span>
-              <span v-if="action.description" class="action-desc">{{ action.description }}</span>
+              <span class="text-[13px] font-semibold leading-[1.4]">{{ action.label }}</span>
+              <span v-if="action.description" class="text-[11px] font-normal text-text-muted text-left leading-[1.4]">{{ action.description }}</span>
             </button>
           </div>
 
-          <h3 class="packs-heading">Or try a shortcut pack</h3>
-          <div class="pack-mini-grid">
+          <h3 class="text-[15px] font-bold text-text-secondary my-6 text-center">Or try a shortcut pack</h3>
+          <div class="grid grid-cols-[repeat(auto-fill,minmax(170px,1fr))] gap-2.5 mb-4">
             <button
               v-for="pack in visiblePacks"
               :key="pack.id"
-              :class="['pack-mini-card', { selected: selectedPacks.some(p => p.id === pack.id) }]"
-              :style="{ '--pack-accent': pack.color }"
+              :class="['flex items-center gap-2.5 px-4 py-3 bg-surface-elevated border border-border-default border-l-[3px] rounded-[14px] cursor-pointer transition-all duration-200 text-left hover:bg-surface-hover hover:-translate-y-px hover:shadow-md', selectedPacks.some(p => p.id === pack.id) ? '!bg-accent-bg !border-accent' : '']"
+              :style="{ borderLeftColor: pack.color || 'var(--blue)' }"
               @click="togglePack(pack)"
               type="button"
             >
-              <span class="pack-mini-icon">{{ pack.icon }}</span>
-              <div class="pack-mini-info">
-                <span class="pack-mini-name">{{ pack.name }}</span>
-                <span class="pack-mini-meta">{{ pack.shortcuts.length }} shortcuts</span>
+              <span class="text-xl shrink-0">{{ pack.icon }}</span>
+              <div class="flex-1 min-w-0 flex flex-col gap-px">
+                <span class="text-sm font-medium text-text-primary truncate">{{ pack.name }}</span>
+                <span class="text-xs text-text-muted">{{ pack.shortcuts.length }} shortcuts</span>
               </div>
-              <div class="checkbox-indicator pack-check">
+              <div :class="['w-5 h-5 rounded-full border-2 border-border-default flex items-center justify-center shrink-0 transition-all duration-200 text-xs ml-auto', { '!border-accent !bg-accent !text-white': selectedPacks.some(p => p.id === pack.id) }]">
                 <i v-if="selectedPacks.some(p => p.id === pack.id)" class="mdi mdi-check"></i>
               </div>
             </button>
           </div>
 
-          <div class="show-more-wrap">
-            <button class="btn-show-more" @click="toggleShowMore" type="button">
+          <div class="text-center mb-4">
+            <button class="text-[13px] text-text-secondary font-semibold bg-transparent border-none cursor-pointer inline-flex items-center gap-1 px-4 py-2 rounded-full transition-all duration-200 hover:bg-surface-elevated hover:text-text-primary" @click="toggleShowMore" type="button">
               {{ showMoreActions ? 'Show fewer' : `Show more (${MORE_ACTIONS.length + MORE_PACKS.length} more)` }}
               <i :class="['mdi', showMoreActions ? 'mdi-chevron-up' : 'mdi-chevron-down']"></i>
             </button>
           </div>
 
-          <div class="step-actions step-1-actions">
+          <div class="flex items-center justify-center mt-6 pt-4 border-t border-border-light">
             <button 
-              class="btn btn-primary btn-next-step" 
+              class="px-4 py-3 border-none rounded-lg text-[15px] font-semibold cursor-pointer transition-all duration-200 flex items-center justify-center gap-2 bg-accent text-white hover:bg-accent-hover w-full max-w-[300px] mx-auto disabled:opacity-50 disabled:cursor-not-allowed"
               @click="goToStep2" 
               :disabled="selectedActions.length === 0 && selectedPacks.length === 0"
               type="button"
@@ -319,39 +319,39 @@ const skip = () => {
         </div>
 
         <!-- Step 2: Record shortcuts -->
-        <div v-else-if="step === 2" class="step-panel">
-          <div class="progress-wrap">
-            <div class="progress-text">Shortcut {{ currentActionIndex + 1 }} of {{ selectedActions.length }}</div>
-            <div class="progress-bar">
-              <div class="progress-fill" :style="{ width: `${((currentActionIndex + 1) / selectedActions.length) * 100}%` }"></div>
-            </div>
+        <div v-else-if="step === 2" class="flex flex-col flex-1 animate-[slideUp_0.3s_cubic-bezier(0.16,1,0.3,1)]">
+          <div class="flex flex-col items-center mb-8 animate-[slideUp_0.3s_ease]" v-if="currentAction">
+            <i :class="['mdi', currentAction.icon, 'text-[56px] text-accent mb-3 bg-accent-bg p-4 rounded-[18px]']"></i>
+            <h2 class="text-2xl font-bold text-text-primary m-0">{{ currentAction.label }}</h2>
           </div>
 
-          <div class="current-action-display" v-if="currentAction">
-            <i :class="['mdi', currentAction.icon]"></i>
-            <h2>{{ currentAction.label }}</h2>
+          <div class="mb-8">
+            <div class="text-[13px] font-semibold text-text-secondary mb-2 text-center uppercase tracking-wider">Shortcut {{ currentActionIndex + 1 }} of {{ selectedActions.length }}</div>
+            <div class="h-2 bg-surface-elevated rounded-full overflow-hidden max-w-[200px] mx-auto">
+              <div class="h-full bg-accent rounded-full transition-all duration-500" :style="{ width: `${((currentActionIndex + 1) / selectedActions.length) * 100}%` }"></div>
+            </div>
           </div>
           
-          <div class="setup-stack">
-            <div class="setup-card">
-              <label class="setup-label">Shortcut</label>
-              <div class="recorder-wrap">
+          <div class="flex flex-col gap-4 w-full max-w-[680px] mx-auto mb-6">
+            <div class="bg-surface-elevated border border-border-default rounded-[18px] p-5 shadow-sm">
+              <label class="block mb-3 text-xs font-bold tracking-[0.08em] uppercase text-text-secondary">Shortcut</label>
+              <div>
                 <ShortcutRecorder v-model="shortcutKey" />
               </div>
-              <p class="setup-hint">Press a shortcut or type it manually. You can change it later.</p>
+              <p class="mt-2.5 mb-0 text-xs text-text-muted">Press a shortcut or type it manually. You can change it later.</p>
             </div>
 
-            <div v-if="currentDraft && currentAction?.id === 'javascript'" class="setup-card">
-              <h3 class="setup-card-title"><i class="mdi mdi-code-braces"></i> JavaScript to run</h3>
-              <p class="setup-card-desc">This code runs on the current page when the shortcut is pressed.</p>
-              <div class="code-editor-wrap onboarding-code-editor">
+            <div v-if="currentDraft && currentAction?.id === 'javascript'" class="bg-surface-elevated border border-border-default rounded-[18px] p-5 shadow-sm">
+              <h3 class="mt-0 mb-1 text-base font-bold text-text-primary"><i class="mdi mdi-code-braces"></i> JavaScript to run</h3>
+              <p class="mt-0 mb-3.5 text-[13px] leading-normal text-text-secondary">This code runs on the current page when the shortcut is pressed.</p>
+              <div class="code-editor-wrap !mb-0">
                 <CodeEditor :modelValue="currentDraft.code" @update:modelValue="currentDraft.code = $event" />
               </div>
             </div>
 
-            <div v-if="currentDraft" class="setup-card">
-              <h3 class="setup-card-title">Where it works</h3>
-              <p class="setup-card-desc">Optionally limit to certain sites or allow in form inputs.</p>
+            <div v-if="currentDraft" class="bg-surface-elevated border border-border-default rounded-[18px] p-5 shadow-sm">
+              <h3 class="mt-0 mb-1 text-base font-bold text-text-primary">Where it works</h3>
+              <p class="mt-0 mb-3.5 text-[13px] leading-normal text-text-secondary">Optionally limit to certain sites or allow in form inputs.</p>
               <div class="activation-bar">
                 <div class="site-filter-inline">
                   <div class="segmented">
@@ -392,27 +392,27 @@ const skip = () => {
                 rows="3"
                 :placeholder="currentDraft.blacklist === 'whitelist' ? 'Sites to activate on…\n*example.com*' : 'Sites to disable on…\n*example.com*'"
               ></textarea>
-              <p v-if="currentDraft.blacklist && currentDraft.blacklist !== 'false'" class="setup-hint">
-                One pattern per line. Wildcards like <code>*://mail.google.com/*</code> work.
+              <p v-if="currentDraft.blacklist && currentDraft.blacklist !== 'false'" class="mt-2.5 mb-0 text-xs text-text-muted">
+                One pattern per line. Wildcards like <code class="bg-surface-card border border-border-default rounded-sm px-[5px] py-px font-mono text-[11px] text-text-primary">*://mail.google.com/*</code> work.
               </p>
             </div>
           </div>
 
-          <div v-if="conflictWarning" class="conflict-warning">
+          <div v-if="conflictWarning" class="flex items-center gap-2 px-3 py-2 bg-warning-bg border border-warning-border rounded-lg text-xs text-warning-text mt-3 font-medium">
             <i class="mdi mdi-alert-outline"></i>
             {{ conflictWarning }}
           </div>
 
-          <div class="step-actions">
-            <button class="btn btn-secondary" @click="goBack" type="button">
+          <div class="flex items-center justify-between mt-6 pt-4 border-t border-border-light">
+            <button class="px-4 py-2 rounded-lg text-[13px] font-semibold cursor-pointer transition-all duration-200 inline-flex items-center gap-1.5 bg-surface-card text-text-secondary border border-border-default hover:bg-surface-hover" @click="goBack" type="button">
               <i class="mdi mdi-arrow-left"></i> Back
             </button>
-            <div class="right-actions">
-              <button class="btn btn-secondary btn-skip" @click="skipCurrent" type="button">
+            <div class="flex gap-2">
+              <button class="text-sm text-text-muted bg-transparent border-none cursor-pointer font-medium hover:text-text-secondary" @click="skipCurrent" type="button">
                 Skip
               </button>
               <button 
-                class="btn btn-primary" 
+                class="px-4 py-2 border-none rounded-lg text-[13px] font-semibold cursor-pointer transition-all duration-200 inline-flex items-center gap-1.5 bg-accent text-white hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed" 
                 @click="recordNext" 
                 :disabled="!canAdvance"
                 type="button"
@@ -424,11 +424,11 @@ const skip = () => {
         </div>
 
         <!-- Step 3: Success -->
-        <div v-else-if="step === 3" class="step-panel success-panel">
-          <div class="confetti-wrap">
-            <i class="mdi mdi-check-circle success-icon"></i>
+        <div v-else-if="step === 3" class="flex flex-col flex-1 animate-[slideUp_0.3s_cubic-bezier(0.16,1,0.3,1)] text-center py-4 items-center justify-center">
+          <div class="text-4xl mb-4 animate-[popIn_0.5s_cubic-bezier(0.16,1,0.3,1)]">
+            <i class="mdi mdi-check-circle text-[48px] mb-3 animate-[popIn_0.5s_cubic-bezier(0.16,1,0.3,1)_0.2s_both] text-success"></i>
           </div>
-          <h2 class="step-title">
+          <h2 class="text-xl font-bold text-text-primary mb-2 tracking-tight">
             <template v-if="recordedShortcuts.length > 0 && selectedPacks.length > 0">
               You created {{ recordedShortcuts.length }} shortcut{{ recordedShortcuts.length === 1 ? '' : 's' }} and added {{ selectedPacks.length }} pack{{ selectedPacks.length === 1 ? '' : 's' }}!
             </template>
@@ -439,30 +439,30 @@ const skip = () => {
               You created {{ recordedShortcuts.length }} shortcut{{ recordedShortcuts.length === 1 ? '' : 's' }}!
             </template>
           </h2>
-          <p class="step-desc">Your shortcuts are ready to use.</p>
+          <p class="text-[15px] text-text-secondary mb-6 leading-relaxed">Your shortcuts are ready to use.</p>
           
-          <div class="success-summary-list" v-if="recordedShortcuts.length > 0 || selectedPacks.length > 0">
-            <div class="success-summary" v-for="(shortcut, idx) in recordedShortcuts" :key="'s-' + idx">
-              <div class="summary-keys">
-                <kbd v-for="k in shortcut.key.split('+')" :key="k">{{ k }}</kbd>
+          <div class="flex flex-col gap-4 mb-8 w-full max-w-[480px] max-h-[250px] overflow-y-auto pr-2" v-if="recordedShortcuts.length > 0 || selectedPacks.length > 0">
+            <div class="flex items-center justify-center gap-4 bg-surface-elevated px-6 py-4 rounded-2xl border border-border-default shadow-sm" v-for="(shortcut, idx) in recordedShortcuts" :key="'s-' + idx">
+              <div class="flex gap-1 min-w-[100px] justify-end">
+                <kbd v-for="k in shortcut.key.split('+')" :key="k" class="inline-block px-3 py-2 bg-surface-card border border-border-default rounded-md font-mono text-sm font-semibold text-text-primary capitalize shadow-[0_3px_0_var(--color-border-default)]">{{ k }}</kbd>
               </div>
-              <i class="mdi mdi-arrow-right summary-arrow"></i>
-              <div class="summary-action">
-                <i :class="['mdi', shortcut.icon]"></i>
+              <i class="mdi mdi-arrow-right text-text-muted text-xl"></i>
+              <div class="flex items-center gap-2 text-[15px] font-semibold text-text-primary text-left">
+                <i :class="['mdi', shortcut.icon, 'text-accent text-xl']"></i>
                 {{ shortcut.actionLabel }}
               </div>
             </div>
-            <div class="success-summary pack-summary" v-for="pack in selectedPacks" :key="'p-' + pack.id">
-              <span class="pack-mini-icon">{{ pack.icon }}</span>
-              <div class="summary-action">
+            <div class="flex items-center justify-center gap-4 bg-surface-elevated px-6 py-4 rounded-2xl border border-border-default shadow-sm" v-for="pack in selectedPacks" :key="'p-' + pack.id">
+              <span class="text-2xl min-w-[100px] text-right shrink-0">{{ pack.icon }}</span>
+              <div class="flex items-center gap-2 text-[15px] font-semibold text-text-primary text-left">
                 <strong>{{ pack.name }}</strong>
-                <span class="pack-summary-meta">{{ pack.shortcuts.length }} shortcuts</span>
+                <span class="text-xs text-text-muted font-normal ml-2">{{ pack.shortcuts.length }} shortcuts</span>
               </div>
             </div>
           </div>
 
-          <div class="step-actions success-actions">
-            <button class="btn btn-primary" @click="finish" type="button">
+          <div class="flex gap-2 justify-center mt-4">
+            <button class="px-4 py-2 border-none rounded-lg text-[13px] font-semibold cursor-pointer transition-all duration-200 inline-flex items-center gap-1.5 bg-accent text-white hover:bg-accent-hover" @click="finish" type="button">
               <i class="mdi mdi-check"></i> Done
             </button>
           </div>
@@ -473,8 +473,8 @@ const skip = () => {
 
     <!-- Pack Preview Modal -->
     <Transition name="modal">
-      <div v-if="previewingPack" class="modal-overlay pack-preview-overlay" @click.self="closePreview">
-        <div class="modal-panel pack-preview-panel">
+      <div v-if="previewingPack" class="modal-overlay z-[1000]" @click.self="closePreview">
+        <div class="modal-panel max-w-[540px]">
           <div class="modal-header" :style="{ background: previewingPack.color }">
             <span class="modal-icon">{{ previewingPack.icon }}</span>
             <div>
@@ -500,8 +500,8 @@ const skip = () => {
             </div>
           </div>
           <div class="modal-footer">
-            <button class="btn btn-secondary" @click="closePreview" type="button">Cancel</button>
-            <button class="btn btn-primary" @click="confirmPack" type="button">
+            <button class="px-4 py-2 rounded-lg text-[13px] font-semibold cursor-pointer transition-all duration-200 inline-flex items-center gap-1.5 bg-surface-card text-text-secondary border border-border-default hover:bg-surface-hover" @click="closePreview" type="button">Cancel</button>
+            <button class="px-4 py-2 border-none rounded-lg text-[13px] font-semibold cursor-pointer transition-all duration-200 inline-flex items-center gap-1.5 bg-accent text-white hover:bg-accent-hover" @click="confirmPack" type="button">
               <i class="mdi mdi-plus"></i> Add {{ previewingPack.shortcuts.length }} shortcut{{ previewingPack.shortcuts.length !== 1 ? 's' : '' }}
             </button>
           </div>
@@ -511,686 +511,3 @@ const skip = () => {
 
   </div>
 </template>
-<style scoped>
-.onboarding-wizard {
-  max-width: 680px;
-  margin: 40px auto;
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: 24px;
-  box-shadow: var(--shadow-xl);
-  overflow: visible;
-  display: flex;
-  flex-direction: column;
-}
-
-.wizard-header {
-  padding: 24px 24px 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-md);
-}
-
-.step-indicator {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-}
-
-.step-dot {
-  width: 32px;
-  height: 32px;
-  border-radius: var(--radius-full);
-  background: var(--bg-elevated);
-  border: 2px solid var(--border);
-  color: var(--text-muted);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 13px;
-  font-weight: 700;
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.step-dot.active {
-  background: var(--blue-bg);
-  border-color: var(--blue);
-  color: var(--blue);
-}
-
-.step-dot.current {
-  background: var(--blue);
-  color: #fff;
-  box-shadow: 0 0 0 6px var(--blue-bg);
-}
-
-.step-label {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-muted);
-  transition: color 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.step-label.active {
-  color: var(--text);
-}
-
-.step-line {
-  width: 40px;
-  height: 2px;
-  background: var(--border);
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.step-line.active {
-  background: var(--blue);
-}
-
-.wizard-content {
-  padding: var(--space-2xl) var(--space-3xl);
-  min-height: 360px;
-  display: flex;
-  flex-direction: column;
-}
-
-.step-panel {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  animation: slideUp 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.step-title {
-  font-size: 24px;
-  font-weight: 700;
-  color: var(--text);
-  margin: 0 0 8px;
-  text-align: center;
-  letter-spacing: -0.02em;
-}
-
-.step-desc {
-  font-size: 15px;
-  color: var(--text-secondary);
-  margin: 0 0 32px;
-  text-align: center;
-}
-
-.action-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: var(--space-md);
-}
-
-.action-card {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-2xl);
-  padding: 20px;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
-  cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-  color: var(--text);
-  text-align: left;
-}
-
-.action-card:hover {
-  background: var(--bg-hover);
-  border-color: var(--border-light);
-  transform: translateY(-3px);
-  box-shadow: var(--shadow-lg);
-}
-
-.action-card.selected {
-  background: var(--blue-bg);
-  border-color: var(--blue);
-  box-shadow: inset 0 2px 8px rgba(0,0,0,0.05);
-}
-
-.action-card-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  width: 100%;
-}
-
-.action-icon {
-  font-size: 32px;
-  color: var(--text-secondary);
-  opacity: 0.9;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.action-card:hover .action-icon {
-  color: var(--blue);
-  transform: scale(1.05);
-  opacity: 1;
-}
-
-.action-card.selected .action-icon {
-  color: var(--blue);
-}
-
-.checkbox-indicator {
-  width: 20px;
-  height: 20px;
-  border-radius: var(--radius-lg);
-  border: 2px solid var(--border-light);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-  background: var(--bg-card);
-}
-
-.action-card.selected .checkbox-indicator {
-  background: var(--blue);
-  border-color: var(--blue);
-  color: white;
-}
-
-.checkbox-indicator .mdi {
-  font-size: 14px;
-  font-weight: bold;
-}
-
-.action-label {
-  font-size: 13px;
-  font-weight: 600;
-  line-height: 1.4;
-}
-
-.show-more-wrap {
-  margin-top: 16px;
-  text-align: center;
-}
-
-.btn-show-more {
-  background: none;
-  border: none;
-  color: var(--text-secondary);
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-xs);
-  padding: 8px 16px;
-  border-radius: var(--radius-full);
-  transition: all 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
-}
-
-.btn-show-more:hover {
-  background: var(--bg-elevated);
-  color: var(--text);
-}
-
-.step-1-actions {
-  justify-content: center;
-  display: flex;
-}
-
-.btn-next-step {
-  width: 100%;
-  max-width: 300px;
-  margin: 0 auto;
-  padding: 12px;
-  font-size: 15px;
-  font-weight: 600;
-  display: flex;
-  justify-content: center;
-  gap: var(--space-sm);
-}
-
-.progress-wrap {
-  margin-bottom: 32px;
-}
-
-.progress-text {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  margin-bottom: 8px;
-  text-align: center;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.progress-bar {
-  height: 8px;
-  background: var(--bg-elevated);
-  border-radius: var(--radius-full);
-  overflow: hidden;
-  max-width: 200px;
-  margin: 0 auto;
-}
-
-.progress-fill {
-  height: 100%;
-  background: var(--blue);
-  border-radius: var(--radius-full);
-  transition: width 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.current-action-display {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-bottom: 32px;
-  animation: slideUp 0.3s ease;
-}
-
-.current-action-display .mdi {
-  font-size: 56px;
-  color: var(--blue);
-  margin-bottom: 12px;
-  background: var(--blue-bg);
-  padding: 16px;
-  border-radius: var(--radius-2xl);
-}
-
-.current-action-display h2 {
-  font-size: 24px;
-  font-weight: 700;
-  color: var(--text);
-  margin: 0;
-}
-
-.setup-stack {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-lg);
-  width: 100%;
-  max-width: 680px;
-  margin: 0 auto 24px;
-}
-
-.setup-card {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-2xl);
-  padding: 20px;
-  box-shadow: var(--shadow-sm);
-}
-
-.setup-label {
-  display: block;
-  margin-bottom: 12px;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-secondary);
-}
-
-.setup-card-title {
-  margin: 0 0 4px;
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--text);
-}
-
-.setup-card-desc {
-  margin: 0 0 14px;
-  font-size: 13px;
-  line-height: 1.5;
-  color: var(--text-secondary);
-}
-
-.setup-hint {
-  margin: 10px 0 0;
-  font-size: 12px;
-  color: var(--text-muted);
-}
-
-.setup-hint code {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 1px 5px;
-  font-family: 'SF Mono', Menlo, monospace;
-  font-size: 11px;
-  color: var(--text);
-}
-
-.setup-card .recorder-wrap {
-  max-width: none;
-  margin: 0;
-}
-
-.onboarding-code-editor {
-  margin-bottom: 0;
-}
-
-.action-desc {
-  font-size: 11px;
-  font-weight: 400;
-  color: var(--text-muted);
-  text-align: left;
-  line-height: 1.4;
-}
-
-.recorder-wrap {
-  max-width: 400px;
-  margin: 0 auto 24px;
-  width: 100%;
-}
-
-.conflict-warning {
-  max-width: 680px;
-  margin: 0 auto 24px;
-  width: 100%;
-  background: var(--warning-bg);
-  border: 1px solid var(--warning-border);
-  color: var(--warning-text);
-  padding: 12px 16px;
-  border-radius: var(--radius-lg);
-  font-size: 13px;
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-}
-
-.step-actions {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: auto;
-  padding-top: 24px;
-}
-
-.right-actions {
-  display: flex;
-  gap: var(--space-md);
-}
-
-.btn-skip {
-  background: transparent;
-  border-color: transparent;
-}
-
-.success-actions {
-  justify-content: center;
-  gap: var(--space-lg);
-}
-
-.success-panel {
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-}
-
-.confetti-wrap {
-  margin-bottom: 16px;
-  animation: popIn 0.6s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.success-icon {
-  font-size: 72px;
-  color: var(--success);
-}
-
-.success-summary-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
-  margin-bottom: 32px;
-  width: 100%;
-  max-width: 480px;
-  max-height: 250px;
-  overflow-y: auto;
-  padding-right: 8px;
-}
-
-.success-summary-list::-webkit-scrollbar {
-  width: 6px;
-}
-.success-summary-list::-webkit-scrollbar-track {
-  background: var(--bg-elevated);
-  border-radius: 3px;
-}
-.success-summary-list::-webkit-scrollbar-thumb {
-  background: var(--border);
-  border-radius: 3px;
-}
-
-.success-summary {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-lg);
-  background: var(--bg-elevated);
-  padding: 16px 24px;
-  border-radius: var(--radius-2xl);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow-sm);
-}
-
-.summary-keys {
-  display: flex;
-  gap: var(--space-xs);
-  min-width: 100px;
-  justify-content: flex-end;
-}
-
-.summary-keys kbd {
-  display: inline-block;
-  padding: 8px 12px;
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  font-family: 'SF Mono', Menlo, monospace;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text);
-  text-transform: capitalize;
-  box-shadow: 0 3px 0 var(--border);
-}
-
-.summary-arrow {
-  color: var(--text-muted);
-  font-size: 20px;
-}
-
-.summary-action {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text);
-  text-align: left;
-}
-
-.summary-action .mdi {
-  color: var(--blue);
-  font-size: 20px;
-}
-
-.btn-skip-top {
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--text-secondary);
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  padding: 8px 16px;
-  border-radius: var(--radius-xl);
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.btn-skip-top:hover {
-  background: var(--bg-elevated);
-  border-color: var(--border-light);
-  color: var(--text);
-}
-
-/* ── Pack mini cards ── */
-.packs-heading {
-  font-size: 15px;
-  font-weight: 700;
-  color: var(--text-secondary);
-  margin: 24px 0 12px;
-  text-align: center;
-}
-
-.pack-mini-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
-  gap: 10px;
-}
-
-.pack-mini-card {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px 16px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-left: 3px solid var(--pack-accent, var(--blue));
-  border-radius: var(--radius-xl);
-  cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-  text-align: left;
-  color: var(--text);
-}
-
-.pack-mini-card:hover {
-  background: var(--bg-hover);
-  border-color: var(--border-light);
-  border-left-color: var(--pack-accent, var(--blue));
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-md);
-}
-
-.pack-mini-icon {
-  font-size: 22px;
-  line-height: 1;
-  flex-shrink: 0;
-}
-
-.pack-mini-info {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
-
-.pack-mini-name {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.pack-mini-meta {
-  font-size: 11px;
-  color: var(--text-muted);
-  font-weight: 500;
-}
-
-.pack-check {
-  margin-left: auto;
-  flex-shrink: 0;
-}
-
-.pack-mini-card.selected {
-  background: var(--blue-bg);
-  border-color: var(--blue);
-  border-left-color: var(--blue);
-}
-
-.pack-mini-card.selected .checkbox-indicator {
-  background: var(--blue);
-  border-color: var(--blue);
-  color: white;
-}
-
-.pack-summary {
-  gap: var(--space-md);
-}
-
-.pack-summary .pack-mini-icon {
-  font-size: 24px;
-  min-width: 100px;
-  text-align: right;
-}
-
-.pack-summary-meta {
-  font-size: 12px;
-  color: var(--text-muted);
-  font-weight: 400;
-  margin-left: 8px;
-}
-
-/* Animations */
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity 0.2s ease;
-}
-
-.fade-enter-from,
-.fade-leave-to {
-  opacity: 0;
-}
-
-/* Staggered grid fade for items */
-.staggered-fade-move,
-.staggered-fade-enter-active,
-.staggered-fade-leave-active {
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.staggered-fade-enter-from,
-.staggered-fade-leave-to {
-  opacity: 0;
-  transform: translateY(10px) scale(0.95);
-}
-
-.staggered-fade-leave-active {
-  position: absolute;
-}
-
-@keyframes slideUp {
-  from {
-    opacity: 0;
-    transform: translateY(15px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes popIn {
-  0% {
-    opacity: 0;
-    transform: scale(0.5) rotate(-10deg);
-  }
-  50% {
-    transform: scale(1.1) rotate(5deg);
-  }
-  100% {
-    opacity: 1;
-    transform: scale(1) rotate(0);
-  }
-}
-
-/* ── Pack Preview Modal ── */
-.pack-preview-overlay {
-  z-index: 1000;
-}
-
-.pack-preview-panel {
-  max-width: 540px;
-}
-</style>

--- a/src/components/PackPreviewModal.vue
+++ b/src/components/PackPreviewModal.vue
@@ -26,67 +26,67 @@ const keyConflictCount = computed(() => {
 
 <template>
   <Transition name="modal">
-    <div v-if="previewPack" class="modal-overlay" @click.self="previewPack = null">
-      <div class="modal-panel">
-        <div class="modal-header" :style="{ background: previewPack.color }">
-          <span class="modal-icon">{{ previewPack.icon }}</span>
+    <div v-if="previewPack" class="fixed inset-0 z-[100] bg-black/30 backdrop-blur-[16px] flex items-center justify-center p-6" @click.self="previewPack = null">
+      <div class="modal-panel bg-surface-card rounded-3xl w-full max-w-[580px] max-h-[85vh] flex flex-col overflow-hidden shadow-xl border border-border-light">
+        <div class="flex items-center gap-4 px-8 py-6 text-white relative" :style="{ background: previewPack.color }">
+          <span class="text-4xl shrink-0">{{ previewPack.icon }}</span>
           <div>
-            <h2 class="modal-title">{{ previewPack.name }}</h2>
-            <p class="modal-subtitle">{{ previewPack.description }}</p>
+            <h2 class="text-lg font-bold m-0">{{ previewPack.name }}</h2>
+            <p class="text-[13px] opacity-85 mt-1 m-0">{{ previewPack.description }}</p>
           </div>
-          <button class="modal-close" @click="previewPack = null" type="button">
+          <button class="absolute top-3 right-3 bg-white/20 border-none text-white w-7 h-7 rounded-full flex items-center justify-center cursor-pointer text-base transition-colors duration-150 hover:bg-white/35" @click="previewPack = null" type="button">
             <i class="mdi mdi-close"></i>
           </button>
         </div>
-        <div class="modal-body">
-          <div class="modal-shortcuts">
+        <div class="px-8 py-6 overflow-y-auto flex-1">
+          <div class="flex flex-col gap-0.5">
             <div
               v-for="(s, si) in previewPack.shortcuts"
               :key="s.key"
-              class="modal-shortcut-row"
+              class="flex justify-between items-center px-4 py-3 rounded-[10px] gap-3 transition-colors duration-200 odd:bg-surface-elevated hover:bg-surface-hover"
               :class="{
-                'modal-shortcut-conflict': conflicts.has(si) && conflicts.get(si)!.type === 'key',
-                'modal-shortcut-exact': conflicts.has(si) && conflicts.get(si)!.type === 'exact',
+                'bg-warning-bg border-l-[3px] border-l-warning-border pl-[9px] rounded-l-lg transition-all duration-400': conflicts.has(si) && conflicts.get(si)!.type === 'key',
+                'bg-info-bg border-l-[3px] border-l-text-muted pl-[9px] opacity-60 rounded-l-lg transition-all duration-400': conflicts.has(si) && conflicts.get(si)!.type === 'exact',
               }"
             >
-              <span class="modal-shortcut-label">
+              <span class="text-[13px] text-text-primary">
                 {{ s.label || s.action }}
-                <span v-if="conflicts.has(si) && conflicts.get(si)!.type === 'exact'" class="conflict-badge exact">duplicate</span>
-                <span v-else-if="conflicts.has(si)" class="conflict-badge key">conflict</span>
+                <span v-if="conflicts.has(si) && conflicts.get(si)!.type === 'exact'" class="inline-block text-[10px] px-[7px] py-[2px] rounded-lg ml-1.5 font-semibold uppercase tracking-wider align-middle transition-all duration-400 bg-surface-hover text-text-secondary">duplicate</span>
+                <span v-else-if="conflicts.has(si)" class="inline-block text-[10px] px-[7px] py-[2px] rounded-lg ml-1.5 font-semibold uppercase tracking-wider align-middle transition-all duration-400 bg-warning-bg text-warning-text">conflict</span>
               </span>
-              <span class="modal-shortcut-keys">
-                <kbd v-for="(part, pi) in s.key.split('+')" :key="pi">{{ part }}</kbd>
+              <span class="flex gap-[3px] shrink-0">
+                <kbd v-for="(part, pi) in s.key.split('+')" :key="pi" class="inline-block px-[7px] py-[2px] bg-surface-hover border border-border-default rounded-[5px] font-mono text-[11px] text-text-secondary capitalize">{{ part }}</kbd>
               </span>
             </div>
           </div>
 
-          <div v-if="exactDuplicateCount > 0" class="modal-exact-notice">
+          <div v-if="exactDuplicateCount > 0" class="flex items-center gap-2 px-4 py-3 bg-info-bg border border-info-border text-info-text rounded-[14px] mt-3 text-[13px] font-medium shadow-sm transition-all duration-400">
             <i class="mdi mdi-information-outline"></i>
             {{ exactDuplicateCount }} exact duplicate{{ exactDuplicateCount > 1 ? 's' : '' }} will be skipped automatically (same key and action already exist)
           </div>
 
-          <div v-if="keyConflictCount > 0" class="modal-conflicts">
-            <div class="modal-conflict-header">
+          <div v-if="keyConflictCount > 0" class="mt-4 px-4 py-3 bg-warning-bg border border-warning-border rounded-[10px]">
+            <div class="text-[13px] font-semibold text-warning-text mb-2.5 flex items-center gap-1.5">
               <i class="mdi mdi-alert-outline"></i>
               {{ keyConflictCount }} shortcut{{ keyConflictCount > 1 ? 's' : '' }} conflict with your existing shortcuts
             </div>
-            <div class="modal-conflict-options">
-              <label class="radio-option">
+            <div class="flex flex-col gap-2">
+              <label class="flex items-center gap-2 text-[13px] text-text-secondary cursor-pointer">
                 <input type="radio" v-model="packConflictMode" value="replace" />
                 <span>Replace my shortcuts with pack versions</span>
               </label>
-              <label class="radio-option">
+              <label class="flex items-center gap-2 text-[13px] text-text-secondary cursor-pointer">
                 <input type="radio" v-model="packConflictMode" value="skip" />
                 <span>Skip conflicting shortcuts</span>
               </label>
-              <label class="radio-option">
+              <label class="flex items-center gap-2 text-[13px] text-text-secondary cursor-pointer">
                 <input type="radio" v-model="packConflictMode" value="keep" />
                 <span>Keep both (I'll sort it out later)</span>
               </label>
             </div>
           </div>
         </div>
-        <div class="modal-footer">
+        <div class="flex justify-end gap-3 px-8 py-5 border-t border-border-default bg-surface-elevated">
           <button class="btn btn-secondary" @click="previewPack = null" type="button">Cancel</button>
           <button class="btn btn-primary" @click="installPack(previewPack)" type="button">
             <i class="mdi mdi-plus"></i> Add {{ addCount }} shortcut{{ addCount !== 1 ? 's' : '' }}
@@ -96,58 +96,3 @@ const keyConflictCount = computed(() => {
     </div>
   </Transition>
 </template>
-
-<style scoped>
-.modal-shortcut-conflict {
-  background: var(--warning-bg);
-  border-left: 3px solid var(--warning-border);
-  padding-left: 9px;
-  border-top-left-radius: var(--radius-md);
-  border-bottom-left-radius: var(--radius-md);
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.modal-shortcut-exact {
-  background: var(--info-bg);
-  border-left: 3px solid var(--text-muted);
-  padding-left: 9px;
-  opacity: 0.6;
-  border-top-left-radius: var(--radius-md);
-  border-bottom-left-radius: var(--radius-md);
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.conflict-badge {
-  display: inline-block;
-  font-size: 10px;
-  padding: 2px 7px;
-  border-radius: var(--radius-md);
-  margin-left: 6px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-  vertical-align: middle;
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.conflict-badge.key {
-  background: var(--warning-bg);
-  color: var(--warning-text);
-}
-.conflict-badge.exact {
-  background: var(--bg-hover);
-  color: var(--text-secondary);
-}
-.modal-exact-notice {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 12px 16px;
-  background: var(--info-bg);
-  border: 1px solid var(--info-border);
-  color: var(--info-text);
-  border-radius: var(--radius-xl);
-  margin-top: 12px;
-  font-size: 13px;
-  font-weight: 500;
-  box-shadow: var(--shadow-sm);
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-</style>

--- a/src/components/PacksTab.vue
+++ b/src/components/PacksTab.vue
@@ -29,19 +29,20 @@ onMounted(() => {
         <p class="tab-desc">One-click install curated shortcut collections. They'll appear as a group you can customize or remove.</p>
       </div>
       
-      <div class="pack-grid">
-        <div v-for="pack in ALL_PACKS" :key="pack.id" class="pack-card" :style="{ borderTopColor: pack.color, '--pack-color': pack.color }">
-          <div class="pack-header">
-            <div class="pack-icon">{{ pack.icon }}</div>
-            <div class="pack-info">
-              <div class="pack-name">{{ pack.name }}</div>
-              <div class="pack-meta">{{ pack.shortcuts.length }} shortcuts</div>
+      <div class="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-4">
+        <div v-for="pack in ALL_PACKS" :key="pack.id" class="bg-surface-card border border-border-default rounded-[14px] p-5 flex flex-col gap-3.5 transition-all duration-250 relative overflow-hidden hover:shadow-md hover:-translate-y-[3px] group">
+          <div class="absolute top-0 left-0 right-0 h-[3px] opacity-0 group-hover:opacity-100 transition-opacity duration-250" :style="{ background: pack.color || 'var(--blue)' }"></div>
+          <div class="flex items-center gap-4 relative z-[1]">
+            <div class="text-[32px] leading-none drop-shadow-[0_2px_4px_rgba(0,0,0,0.1)] transition-transform duration-200 group-hover:scale-110 group-hover:-rotate-[5deg]">{{ pack.icon }}</div>
+            <div class="flex-1 flex flex-col gap-0.5">
+              <div class="text-base font-bold text-text-primary tracking-tight">{{ pack.name }}</div>
+              <div class="text-xs font-semibold text-text-muted uppercase tracking-wider">{{ pack.shortcuts.length }} shortcuts</div>
             </div>
           </div>
-          <div class="pack-desc">{{ pack.description }}</div>
-          <div class="pack-actions">
-            <button class="btn btn-secondary btn-sm" @click="previewPack = pack" type="button">Preview</button>
-            <button class="btn btn-primary btn-sm" @click="previewPack = pack" type="button">
+          <div class="text-[13px] text-text-secondary leading-relaxed flex-1 relative z-[1]">{{ pack.description }}</div>
+          <div class="flex gap-2 mt-auto relative z-[1]">
+            <button class="btn btn-secondary btn-sm flex-1 justify-center" @click="previewPack = pack" type="button">Preview</button>
+            <button class="btn btn-primary btn-sm flex-1 justify-center" @click="previewPack = pack" type="button">
               <i class="mdi mdi-plus"></i> Add
             </button>
           </div>
@@ -59,14 +60,14 @@ onMounted(() => {
       </div>
 
       <!-- Loading -->
-      <div v-if="communityLoading" class="community-loading">
-        <i class="mdi mdi-loading mdi-spin"></i>
+      <div v-if="communityLoading" class="flex flex-col items-center justify-center py-12 px-6 text-center text-text-muted bg-surface-elevated rounded-[18px] border border-dashed border-border-default gap-3 transition-all duration-400">
+        <i class="mdi mdi-loading mdi-spin text-[32px] opacity-50"></i>
         <span>Loading community packs…</span>
       </div>
 
       <!-- Error -->
-      <div v-else-if="communityError" class="community-error">
-        <i class="mdi mdi-alert-circle-outline"></i>
+      <div v-else-if="communityError" class="flex flex-col items-center justify-center py-12 px-6 text-center text-text-muted bg-surface-elevated rounded-[18px] border border-dashed border-border-default gap-3 transition-all duration-400 !text-danger !bg-danger-bg !border-danger-border">
+        <i class="mdi mdi-alert-circle-outline text-[32px] opacity-50"></i>
         <span>{{ communityError }}</span>
         <button class="btn btn-secondary btn-sm" @click="fetchCommunityPacks" type="button">
           <i class="mdi mdi-refresh"></i> Retry
@@ -76,8 +77,8 @@ onMounted(() => {
       <!-- Loaded -->
       <template v-else>
         <!-- Filters -->
-        <div class="community-filters">
-          <div class="search-wrap">
+        <div class="mb-6">
+          <div class="search-wrap max-w-[400px]">
             <i class="mdi mdi-magnify search-icon"></i>
             <input
               class="search-input"
@@ -92,26 +93,27 @@ onMounted(() => {
         </div>
 
         <!-- Empty -->
-        <div v-if="filteredCommunityPacks.length === 0" class="community-empty">
-          <i class="mdi mdi-package-variant-closed"></i>
+        <div v-if="filteredCommunityPacks.length === 0" class="flex flex-col items-center justify-center py-12 px-6 text-center text-text-muted bg-surface-elevated rounded-[18px] border border-dashed border-border-default gap-3 transition-all duration-400">
+          <i class="mdi mdi-package-variant-closed text-[32px] opacity-50"></i>
           <span>No community packs found{{ communitySearchQuery ? ' matching your search' : '' }}</span>
         </div>
 
         <!-- Pack grid -->
-        <div v-else class="pack-grid">
-          <div v-for="pack in filteredCommunityPacks" :key="pack.id" class="pack-card" :style="{ borderTopColor: pack.color, '--pack-color': pack.color }">
-            <div class="pack-header">
-              <div class="pack-icon">{{ pack.icon }}</div>
-              <div class="pack-info">
-                <div class="pack-name">{{ pack.name }} <span class="community-badge">Community</span></div>
-                <div class="pack-meta">{{ pack.shortcutCount }} shortcuts</div>
+        <div v-else class="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-4">
+          <div v-for="pack in filteredCommunityPacks" :key="pack.id" class="bg-surface-card border border-border-default rounded-[14px] p-5 flex flex-col gap-3.5 transition-all duration-250 relative overflow-hidden hover:shadow-md hover:-translate-y-[3px] group">
+            <div class="absolute top-0 left-0 right-0 h-[3px] opacity-0 group-hover:opacity-100 transition-opacity duration-250" :style="{ background: pack.color || 'var(--blue)' }"></div>
+            <div class="flex items-center gap-4 relative z-[1]">
+              <div class="text-[32px] leading-none drop-shadow-[0_2px_4px_rgba(0,0,0,0.1)] transition-transform duration-200 group-hover:scale-110 group-hover:-rotate-[5deg]">{{ pack.icon }}</div>
+              <div class="flex-1 flex flex-col gap-0.5">
+                <div class="text-base font-bold text-text-primary tracking-tight">{{ pack.name }} <span class="bg-surface-hover px-2 py-0.5 rounded-lg text-[10px] uppercase tracking-wider font-semibold text-text-muted transition-all duration-400">Community</span></div>
+                <div class="text-xs font-semibold text-text-muted uppercase tracking-wider">{{ pack.shortcutCount }} shortcuts</div>
               </div>
             </div>
-            <div class="pack-author"><i class="mdi mdi-account"></i> {{ pack.author }}</div>
-            <div class="pack-desc">{{ pack.description }}</div>
-            <div class="pack-actions">
-              <button class="btn btn-secondary btn-sm" @click="previewCommunityPack = pack" type="button">Preview</button>
-              <button class="btn btn-primary btn-sm" @click="requestInstallCommunityPack(pack)" type="button">
+            <div class="flex items-center gap-1 text-[13px] text-text-secondary -mt-1.5"><i class="mdi mdi-account"></i> {{ pack.author }}</div>
+            <div class="text-[13px] text-text-secondary leading-relaxed flex-1 relative z-[1]">{{ pack.description }}</div>
+            <div class="flex gap-2 mt-auto relative z-[1]">
+              <button class="btn btn-secondary btn-sm flex-1 justify-center" @click="previewCommunityPack = pack" type="button">Preview</button>
+              <button class="btn btn-primary btn-sm flex-1 justify-center" @click="requestInstallCommunityPack(pack)" type="button">
                 <i class="mdi mdi-plus"></i> Add
               </button>
             </div>
@@ -121,54 +123,3 @@ onMounted(() => {
     </div>
   </div>
 </template>
-
-<style scoped>
-.community-filters {
-  margin-bottom: 24px;
-}
-.community-filters .search-wrap {
-  max-width: 400px;
-}
-.community-loading, .community-error, .community-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 48px 24px;
-  text-align: center;
-  color: var(--text-muted);
-  background: var(--bg-elevated);
-  border-radius: var(--radius-2xl);
-  border: 1px dashed var(--border);
-  gap: 12px;
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.community-loading .mdi, .community-error .mdi, .community-empty .mdi {
-  font-size: 32px;
-  opacity: 0.5;
-}
-.community-error {
-  color: var(--danger);
-  background: var(--danger-bg);
-  border-color: var(--danger-border);
-}
-.pack-author {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-  font-size: 13px;
-  color: var(--text-secondary);
-  margin-top: -6px;
-}
-.community-badge {
-  background: var(--bg-hover);
-  padding: 2px 8px;
-  border-radius: var(--radius-md);
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  font-weight: 600;
-  color: var(--text-muted);
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-}
-</style>

--- a/src/components/SearchSelect.vue
+++ b/src/components/SearchSelect.vue
@@ -117,156 +117,48 @@ watch(isOpen, (val) => {
 </script>
 
 <template>
-  <div class="search-select">
-    <button v-if="!isOpen" class="ss-trigger" @click="open" type="button">
-      <span :class="['ss-trigger-text', { placeholder: !modelValue }]">
+  <div class="search-select relative w-full">
+    <button v-if="!isOpen" class="w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-[10px] bg-surface-input text-sm text-text-primary cursor-pointer flex items-center justify-between text-left transition-[border-color,box-shadow] duration-150 hover:border-text-placeholder focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)]" @click="open" type="button">
+      <span :class="['flex-1 overflow-hidden text-ellipsis whitespace-nowrap', { 'text-text-muted': !modelValue }]">
         {{ selectedLabel || placeholder || 'Choose…' }}
       </span>
-      <i class="mdi mdi-chevron-down ss-chevron"></i>
+      <i class="mdi mdi-chevron-down text-text-muted text-base shrink-0"></i>
     </button>
 
-    <div v-else class="ss-dropdown-wrap">
+    <div v-else class="relative">
       <input
         ref="inputRef"
-        class="ss-search"
+        class="w-full px-3 py-[9px] border-[1.5px] border-accent rounded-t-[10px] text-sm text-text-primary bg-surface-input outline-none shadow-[var(--focus-ring)]"
         type="text"
         v-model="query"
         :placeholder="selectedLabel || 'Type to search…'"
         @keydown="onKeydown"
       />
-      <div ref="listRef" class="ss-dropdown">
+      <div ref="listRef" class="absolute top-full left-0 right-0 max-h-[280px] overflow-y-auto bg-surface-input border-[1.5px] border-border-default border-t-0 rounded-b-[10px] shadow-xl z-[100] p-1.5 backdrop-blur-sm">
         <template v-if="filtered.length">
           <template v-for="(opts, group) in groupedFiltered" :key="group">
-            <div class="ss-group-label">{{ group }}</div>
+            <div class="px-3 pt-2 pb-1.5 text-xs font-bold uppercase tracking-wider text-text-muted bg-surface-hover sticky top-0">{{ group }}</div>
             <button
               v-for="opt in opts"
               :key="opt.value"
               :class="[
-                'ss-option',
+                'block w-full px-3 py-[9px] pl-3 my-[3px] border-none rounded-lg bg-none text-left text-sm text-text-primary cursor-pointer transition-all duration-150',
                 {
-                  selected: opt.value === modelValue,
-                  highlighted: filtered.indexOf(opt) === highlightIndex,
+                  'text-accent font-semibold': opt.value === modelValue,
+                  'highlighted bg-surface-hover pl-4 text-accent': filtered.indexOf(opt) === highlightIndex,
                 },
               ]"
               @mouseenter="highlightIndex = filtered.indexOf(opt)"
               @click="select(opt.value)"
               type="button"
             >
-              <span class="ss-opt-label">{{ opt.label }}</span>
-              <span v-if="opt.sublabel" class="ss-opt-sub">{{ opt.sublabel }}</span>
+              <span class="block">{{ opt.label }}</span>
+              <span v-if="opt.sublabel" class="block text-xs text-text-muted whitespace-nowrap overflow-hidden text-ellipsis max-w-full">{{ opt.sublabel }}</span>
             </button>
           </template>
         </template>
-        <div v-else class="ss-empty">No matching actions</div>
+        <div v-else class="p-4 text-center text-text-muted text-[13px] italic">No matching actions</div>
       </div>
     </div>
   </div>
 </template>
-
-<style scoped>
-.search-select { position: relative; width: 100%; }
-
-.ss-trigger {
-  width: 100%;
-  padding: var(--space-sm) var(--space-md);
-  border: 1.5px solid var(--border, #e2e8f0);
-  border-radius: var(--radius-lg);
-  background: var(--bg-input, #fff);
-  font-size: 14px;
-  color: var(--text, #1a1a2e);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  text-align: left;
-  transition: border-color 0.15s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.15s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.ss-trigger:hover { border-color: var(--text-placeholder, #cbd5e1); }
-.ss-trigger:focus { outline: none; border-color: var(--blue, #4361ee); box-shadow: var(--focus-ring); }
-
-.ss-trigger-text { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ss-trigger-text.placeholder { color: var(--text-muted, #94a3b8); }
-.ss-chevron { color: var(--text-muted, #94a3b8); font-size: 16px; flex-shrink: 0; }
-
-.ss-dropdown-wrap { position: relative; }
-
-.ss-search {
-  width: 100%;
-  padding: var(--space-sm) var(--space-md);
-  border: 1.5px solid var(--blue, #4361ee);
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-  font-size: 14px;
-  color: var(--text, #1a1a2e);
-  background: var(--bg-input, #fff);
-  outline: none;
-  box-shadow: var(--focus-ring);
-}
-
-.ss-dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  max-height: 280px;
-  overflow-y: auto;
-  background: var(--bg-input, #fff);
-  border: 1.5px solid var(--border, #e2e8f0);
-  border-top: none;
-  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
-  box-shadow: var(--shadow-xl);
-  z-index: 100;
-  padding: 6px;
-  backdrop-filter: blur(8px);
-}
-[data-theme="dark"] .ss-dropdown {
-  border-color: var(--border);
-  box-shadow: var(--shadow-xl);
-}
-
-.ss-group-label {
-  padding: 6px var(--space-md) 4px;
-  font-size: 12px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-  color: var(--text-muted, #94a3b8);
-  background: var(--bg-hover, #f1f5f9);
-  position: sticky;
-  top: 0;
-}
-
-.ss-option {
-  display: block;
-  width: 100%;
-  padding: 7px var(--space-md) 7px 12px;
-  margin: 3px 0;
-  border: none;
-  border-radius: var(--radius-md);
-  background: none;
-  text-align: left;
-  font-size: 13px;
-  color: var(--text, #334155);
-  cursor: pointer;
-  transition: all 0.15s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.ss-option.highlighted { 
-  background: var(--bg-hover, #f1f5f9); 
-  padding-left: 16px;
-  color: var(--blue, #4361ee);
-}
-.ss-option.selected { color: var(--blue, #4361ee); font-weight: 600; }
-
-.ss-opt-label { display: block; }
-.ss-opt-sub {
-  display: block;
-  font-size: 11px;
-  color: var(--text-muted, #94a3b8);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 100%;
-}
-
-.ss-empty { padding: var(--space-lg); text-align: center; color: var(--text-muted, #94a3b8); font-size: 13px; font-style: italic; }
-
-</style>

--- a/src/components/ShortcutDetails.vue
+++ b/src/components/ShortcutDetails.vue
@@ -30,7 +30,7 @@ function isBookmarkAction(action: string): boolean {
 </script>
 
 <template>
-  <div class="shortcut-details">
+  <div class="shortcut-details border-t border-border-light px-5 py-4 bg-surface-elevated">
 
     <article v-if="isBuiltInAction(keys[index].action)" class="alert alert-info">
       <i class="mdi mdi-information-outline"></i>
@@ -38,53 +38,53 @@ function isBookmarkAction(action: string): boolean {
     </article>
 
     <!-- Code editor for JS (full-width, prominent) -->
-    <div v-if="keys[index].action === 'javascript'" class="code-editor-wrap">
-      <div class="code-header">
-        <span class="code-title"><i class="mdi mdi-code-braces"></i> JavaScript</span>
-        <div class="code-actions">
-          <span class="run-label">Test on:</span>
-          <div class="tab-picker" @click="refreshTabs">
+    <div v-if="keys[index].action === 'javascript'" class="rounded-[10px] overflow-hidden border border-border-default mb-1">
+      <div class="flex justify-between items-center px-3.5 py-2.5 bg-[#282c34] gap-2">
+        <span class="text-text-muted text-[13px] font-semibold tracking-wider flex items-center gap-1.5 shrink-0"><i class="mdi mdi-code-braces"></i> JavaScript</span>
+        <div class="flex items-center gap-1.5">
+          <span class="text-text-secondary text-[13px] whitespace-nowrap">Test on:</span>
+          <div class="flex items-center gap-1 bg-[#334155] rounded-lg px-2 h-[30px]" @click="refreshTabs">
             <i class="mdi mdi-tab"></i>
-            <select v-model="selectedTabId" class="tab-picker-select">
+            <select v-model="selectedTabId" class="bg-transparent border-none text-[#e2e8f0] text-[13px] outline-none cursor-pointer max-w-[200px] p-0">
               <option v-for="t in openTabs" :key="t.id" :value="t.id">
                 {{ t.title.substring(0, 35) }}{{ t.title.length > 35 ? '…' : '' }}
               </option>
             </select>
           </div>
-          <button class="btn-run" @click="testJavascript(keys[index])" type="button">
+          <button class="px-4 py-1.5 text-[13px] rounded-lg bg-success text-white border-none cursor-pointer font-semibold flex items-center gap-1 transition-colors duration-150 h-[30px] whitespace-nowrap hover:bg-success-hover" @click="testJavascript(keys[index])" type="button">
             <i class="mdi mdi-play"></i> Run
           </button>
         </div>
       </div>
       <CodeEditor :modelValue="keys[index].code || ''" @update:modelValue="keys[index].code = $event" />
     </div>
-    <div v-if="keys[index].action === 'javascript'" class="import-userscript">
-      <div class="import-userscript-row">
-        <i class="mdi mdi-link-variant import-icon"></i>
+    <div v-if="keys[index].action === 'javascript'" class="pt-2.5">
+      <div class="flex gap-1.5 items-center">
+        <i class="mdi mdi-link-variant text-text-muted text-base shrink-0"></i>
         <input
           v-model="userscriptUrl"
-          class="import-userscript-input"
+          class="flex-1 bg-surface-input border border-border-default rounded-lg text-text-primary text-xs px-2.5 py-[7px] outline-none focus:border-accent placeholder:text-text-placeholder"
           placeholder="Paste a Greasyfork or userscript URL to import…"
           @keydown.enter="importUserscript(index)"
         />
-        <button class="btn-fetch" @click="importUserscript(index)" type="button" :disabled="userscriptLoading">
+        <button class="flex items-center gap-1 px-3.5 py-[7px] rounded-lg border border-border-default bg-surface-card text-text-secondary text-xs cursor-pointer whitespace-nowrap hover:bg-surface-hover hover:text-text-primary disabled:opacity-50 disabled:cursor-not-allowed" @click="importUserscript(index)" type="button" :disabled="userscriptLoading">
           <i :class="['mdi', userscriptLoading ? 'mdi-loading mdi-spin' : 'mdi-download']"></i> Fetch
         </button>
       </div>
-      <span v-if="userscriptMessage" class="import-userscript-msg">{{ userscriptMessage }}</span>
+      <span v-if="userscriptMessage" class="block text-[11px] mt-1 text-text-muted">{{ userscriptMessage }}</span>
     </div>
 
     <!-- Action-specific settings -->
-    <div class="details-section">
-      <div v-if="isScrollAction(keys[index].action)" class="toggle-row-inline">
-        <span class="toggle-label-sm">Smooth scrolling</span>
+    <div class="flex flex-col gap-3 empty:hidden">
+      <div v-if="isScrollAction(keys[index].action)" class="flex items-center gap-2.5 px-3.5 py-2 bg-surface-card border border-border-default rounded-[10px] whitespace-nowrap shrink-0">
+        <span class="text-[13px] font-medium text-text-secondary">Smooth scrolling</span>
         <button :class="['toggle', { on: keys[index].smoothScrolling }]" @click="keys[index].smoothScrolling = !keys[index].smoothScrolling" type="button">
           <span class="toggle-knob"></span>
         </button>
       </div>
 
       <div v-if="isBookmarkAction(keys[index].action)" class="detail-field">
-        <label>Bookmark</label>
+        <label class="block text-[13px] font-medium text-text-secondary mb-1">Bookmark</label>
         <SearchSelect
           :modelValue="keys[index].bookmark || ''"
           @update:modelValue="keys[index].bookmark = $event"
@@ -93,83 +93,83 @@ function isBookmarkAction(action: string): boolean {
         />
       </div>
 
-      <div v-if="keys[index].action === 'gototabbytitle'" class="detail-row">
-        <div class="detail-field flex-1">
-          <label>Title to match <span class="hint">(wildcards)</span></label>
-          <input class="field-input" v-model="keys[index].matchtitle" placeholder="*Gmail*" />
+      <div v-if="keys[index].action === 'gototabbytitle'" class="flex gap-3 items-end">
+        <div class="detail-field flex-1 min-w-0">
+          <label class="block text-[13px] font-medium text-text-secondary mb-1">Title to match <span class="font-normal text-text-muted">(wildcards)</span></label>
+          <input class="field-input w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)]" v-model="keys[index].matchtitle" placeholder="*Gmail*" />
         </div>
-        <div class="toggle-row-inline">
-          <span class="toggle-label-sm">Current window only</span>
+        <div class="flex items-center gap-2.5 px-3.5 py-2 bg-surface-card border border-border-default rounded-[10px] whitespace-nowrap shrink-0">
+          <span class="text-[13px] font-medium text-text-secondary">Current window only</span>
           <button :class="['toggle', { on: keys[index].currentWindow }]" @click="keys[index].currentWindow = !keys[index].currentWindow" type="button">
             <span class="toggle-knob"></span>
           </button>
         </div>
       </div>
 
-      <div v-if="keys[index].action === 'gototab'" class="detail-row">
-        <div class="detail-field flex-1">
-          <label>URL to match <a class="hint-link" target="_blank" href="https://developer.chrome.com/extensions/match_patterns">pattern help →</a></label>
-          <input class="field-input" v-model="keys[index].matchurl" placeholder="*://mail.google.com/*" />
+      <div v-if="keys[index].action === 'gototab'" class="flex gap-3 items-end">
+        <div class="detail-field flex-1 min-w-0">
+          <label class="block text-[13px] font-medium text-text-secondary mb-1">URL to match <a class="font-normal text-accent text-xs" target="_blank" href="https://developer.chrome.com/extensions/match_patterns">pattern help →</a></label>
+          <input class="field-input w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)]" v-model="keys[index].matchurl" placeholder="*://mail.google.com/*" />
         </div>
-        <div class="detail-field flex-1">
-          <label>Fallback URL <span class="hint">(if no match)</span></label>
-          <input class="field-input" v-model="keys[index].openurl" placeholder="https://mail.google.com" />
+        <div class="detail-field flex-1 min-w-0">
+          <label class="block text-[13px] font-medium text-text-secondary mb-1">Fallback URL <span class="font-normal text-text-muted">(if no match)</span></label>
+          <input class="field-input w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)]" v-model="keys[index].openurl" placeholder="https://mail.google.com" />
         </div>
-        <div class="toggle-row-inline">
-          <span class="toggle-label-sm">Current window</span>
+        <div class="flex items-center gap-2.5 px-3.5 py-2 bg-surface-card border border-border-default rounded-[10px] whitespace-nowrap shrink-0">
+          <span class="text-[13px] font-medium text-text-secondary">Current window</span>
           <button :class="['toggle', { on: keys[index].currentWindow }]" @click="keys[index].currentWindow = !keys[index].currentWindow" type="button">
             <span class="toggle-knob"></span>
           </button>
         </div>
       </div>
 
-      <div v-if="keys[index].action === 'gototabbyindex'" class="detail-row">
+      <div v-if="keys[index].action === 'gototabbyindex'" class="flex gap-3 items-end">
         <div class="detail-field" style="max-width: 160px">
-          <label>Tab index <span class="hint">(from 1)</span></label>
-          <input class="field-input" type="number" v-model="keys[index].matchindex" min="1" />
+          <label class="block text-[13px] font-medium text-text-secondary mb-1">Tab index <span class="font-normal text-text-muted">(from 1)</span></label>
+          <input class="field-input w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)]" type="number" v-model="keys[index].matchindex" min="1" />
         </div>
       </div>
 
       <div v-if="keys[index].action === 'buttonnexttab'" class="detail-field">
-        <label>Button CSS selector</label>
-        <input class="field-input mono" v-model="keys[index].button" placeholder="#submit-btn" />
+        <label class="block text-[13px] font-medium text-text-secondary mb-1">Button CSS selector</label>
+        <input class="field-input w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)] font-mono" v-model="keys[index].button" placeholder="#submit-btn" />
       </div>
 
       <div v-if="keys[index].action === 'openurl'" class="detail-field">
-        <label>URL to open</label>
-        <input class="field-input mono" v-model="keys[index].openurl" placeholder="https://example.com" />
+        <label class="block text-[13px] font-medium text-text-secondary mb-1">URL to open</label>
+        <input class="field-input w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)] font-mono" v-model="keys[index].openurl" placeholder="https://example.com" />
       </div>
 
       <div v-if="['grouptab', 'togglegrouptab', 'namegroup'].includes(keys[index].action)" class="detail-field">
-        <label>Group name</label>
-        <input class="field-input" v-model="keys[index].groupname" placeholder="e.g. Research" />
+        <label class="block text-[13px] font-medium text-text-secondary mb-1">Group name</label>
+        <input class="field-input w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)]" v-model="keys[index].groupname" placeholder="e.g. Research" />
       </div>
 
       <div v-if="keys[index].action === 'openapp'" class="detail-field">
-        <label>App ID <span class="hint">(from extensions page)</span></label>
-        <input class="field-input mono" v-model="keys[index].openappid" />
+        <label class="block text-[13px] font-medium text-text-secondary mb-1">App ID <span class="font-normal text-text-muted">(from extensions page)</span></label>
+        <input class="field-input w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)] font-mono" v-model="keys[index].openappid" />
       </div>
 
       <div v-if="keys[index].action === 'trigger'" class="detail-field" style="max-width: 250px">
-        <label>Shortcut to trigger</label>
-        <input class="field-input shortcut-input" v-model="keys[index].trigger" placeholder="e.g. ctrl+b" />
+        <label class="block text-[13px] font-medium text-text-secondary mb-1">Shortcut to trigger</label>
+        <input class="field-input w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)] shortcut-input" v-model="keys[index].trigger" placeholder="e.g. ctrl+b" />
       </div>
 
       <div v-if="keys[index].action === 'inserttext'" class="detail-field">
-        <label>Text to insert</label>
-        <textarea class="field-textarea mono" v-model="keys[index].inserttext" rows="2" placeholder="Text to type into the focused field…"></textarea>
+        <label class="block text-[13px] font-medium text-text-secondary mb-1">Text to insert</label>
+        <textarea class="field-textarea w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)] resize-y font-mono" v-model="keys[index].inserttext" rows="2" placeholder="Text to type into the focused field…"></textarea>
       </div>
-      <div v-if="keys[index].action === 'macro'" class="macro-builder">
-        <div class="field-label-row">
-          <label class="macro-label"><i class="mdi mdi-playlist-play"></i> Macro steps <span class="hint">(max {{ MAX_MACRO_STEPS }})</span></label>
-          <button class="btn-chain-link" @click="convertToSingleAction(keys[index])" type="button">
+      <div v-if="keys[index].action === 'macro'" class="w-full">
+        <div class="field-label-row flex items-baseline justify-between gap-2">
+          <label class="block text-[13px] font-semibold text-text-secondary mb-2"><i class="mdi mdi-playlist-play"></i> Macro steps <span class="font-normal text-text-muted">(max {{ MAX_MACRO_STEPS }})</span></label>
+          <button class="inline-flex items-center gap-[3px] p-0 text-[11px] font-medium text-accent bg-none border-none cursor-pointer opacity-60 transition-opacity duration-150 whitespace-nowrap hover:opacity-100" @click="convertToSingleAction(keys[index])" type="button">
             <i class="mdi mdi-arrow-left"></i> Use single action
           </button>
         </div>
-        <div class="macro-steps">
-          <div v-for="(step, si) in (keys[index].macroSteps || [])" :key="si" class="macro-step">
-            <span class="macro-step-num">{{ si + 1 }}</span>
-            <div class="macro-step-action">
+        <div class="flex flex-col gap-1.5 mb-2">
+          <div v-for="(step, si) in (keys[index].macroSteps || [])" :key="si" class="flex items-center gap-2 px-2.5 py-2 bg-surface-card border border-border-default rounded-[10px] flex-wrap">
+            <span class="text-xs font-semibold text-text-muted min-w-[18px] text-center">{{ si + 1 }}</span>
+            <div class="flex-1 min-w-0">
               <SearchSelect
                 :modelValue="step.action"
                 @update:modelValue="step.action = $event"
@@ -177,75 +177,75 @@ function isBookmarkAction(action: string): boolean {
                 placeholder="Choose action…"
               />
             </div>
-            <div class="macro-step-delay">
+            <div class="flex items-center gap-0.5 shrink-0">
               <input
                 type="number"
-                class="field-input delay-input"
+                class="field-input w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)] !w-[70px] !text-right !px-2 !py-[7px] !text-xs"
                 :value="step.delay || 0"
                 @input="step.delay = parseInt(($event.target as HTMLInputElement).value) || 0"
                 min="0"
                 step="100"
                 title="Delay before this step (ms)"
               />
-              <span class="delay-unit">ms</span>
+              <span class="text-[11px] text-text-muted">ms</span>
             </div>
-            <div class="macro-step-controls">
-              <button class="btn-icon btn-sm" @click="moveMacroStep(keys[index], si, 'up')" :disabled="si === 0" title="Move up" type="button">
+            <div class="flex gap-0.5 shrink-0">
+              <button class="btn-icon p-1.5 flex items-center justify-center border border-transparent rounded-lg bg-transparent text-text-muted cursor-pointer transition-all duration-150 text-base shrink-0 hover:bg-surface-hover hover:text-text-secondary hover:border-border-default !px-3 !py-1 !text-xs" @click="moveMacroStep(keys[index], si, 'up')" :disabled="si === 0" title="Move up" type="button">
                 <i class="mdi mdi-arrow-up"></i>
               </button>
-              <button class="btn-icon btn-sm" @click="moveMacroStep(keys[index], si, 'down')" :disabled="si === (keys[index].macroSteps || []).length - 1" title="Move down" type="button">
+              <button class="btn-icon p-1.5 flex items-center justify-center border border-transparent rounded-lg bg-transparent text-text-muted cursor-pointer transition-all duration-150 text-base shrink-0 hover:bg-surface-hover hover:text-text-secondary hover:border-border-default !px-3 !py-1 !text-xs" @click="moveMacroStep(keys[index], si, 'down')" :disabled="si === (keys[index].macroSteps || []).length - 1" title="Move down" type="button">
                 <i class="mdi mdi-arrow-down"></i>
               </button>
-              <button class="btn-icon btn-sm btn-delete" @click="removeMacroStep(keys[index], si)" title="Remove step" type="button">
+              <button class="btn-icon p-1.5 flex items-center justify-center border border-transparent rounded-lg bg-transparent text-text-muted cursor-pointer transition-all duration-150 text-base shrink-0 hover:bg-surface-hover hover:text-text-secondary hover:border-border-default !px-3 !py-1 !text-xs btn-delete" @click="removeMacroStep(keys[index], si)" title="Remove step" type="button">
                 <i class="mdi mdi-close"></i>
               </button>
             </div>
             <!-- Code editor for JS macro step -->
-            <div v-if="step.action === 'javascript'" class="macro-step-code">
+            <div v-if="step.action === 'javascript'" class="w-full mt-1">
               <CodeEditor :modelValue="step.code || ''" @update:modelValue="step.code = $event" />
             </div>
           </div>
         </div>
         <button
           v-if="(keys[index].macroSteps || []).length < MAX_MACRO_STEPS"
-          class="btn-add-step"
+          class="inline-flex items-center gap-1 px-3.5 py-1.5 text-[13px] font-medium text-accent bg-transparent border border-dashed border-accent rounded-[10px] cursor-pointer transition-colors duration-150 hover:bg-surface-hover"
           @click="addMacroStep(keys[index])"
           type="button"
         >
           <i class="mdi mdi-plus"></i> Add step
         </button>
-        <p v-if="(keys[index].macroSteps || []).length === 0" class="macro-empty">
+        <p v-if="(keys[index].macroSteps || []).length === 0" class="text-[13px] text-text-muted m-0 py-2">
           No steps yet. Add actions that will run sequentially when this shortcut is pressed.
         </p>
       </div>
     </div>
 
     <!-- Activation bar: website filter + form inputs toggle -->
-    <div class="activation-bar">
-      <div class="site-filter-inline">
-        <div class="segmented">
+    <div class="flex items-center gap-3 mt-3 pt-3 border-t border-border-light">
+      <div class="flex-1">
+        <div class="flex bg-surface-hover rounded-[10px] p-[3px] gap-0.5 border border-border-light">
           <button
-            :class="['seg-btn', { active: !keys[index].blacklist || keys[index].blacklist === 'false' }]"
+            :class="['flex-1 px-2.5 py-2 border-none rounded-lg bg-transparent text-text-muted text-[13px] font-medium cursor-pointer transition-all duration-200 flex items-center justify-center gap-1 whitespace-nowrap hover:text-text-primary', { '!bg-surface-card !text-accent !shadow-sm !font-semibold': !keys[index].blacklist || keys[index].blacklist === 'false' }]"
             @click="keys[index].blacklist = false" type="button"
           >
             <i class="mdi mdi-earth"></i> All sites
           </button>
           <button
-            :class="['seg-btn', { active: keys[index].blacklist === true || keys[index].blacklist === 'true' }]"
+            :class="['flex-1 px-2.5 py-2 border-none rounded-lg bg-transparent text-text-muted text-[13px] font-medium cursor-pointer transition-all duration-200 flex items-center justify-center gap-1 whitespace-nowrap hover:text-text-primary', { '!bg-surface-card !text-accent !shadow-sm !font-semibold': keys[index].blacklist === true || keys[index].blacklist === 'true' }]"
             @click="keys[index].blacklist = true" type="button"
           >
             <i class="mdi mdi-earth-minus"></i> Except…
           </button>
           <button
-            :class="['seg-btn', { active: keys[index].blacklist === 'whitelist' }]"
+            :class="['flex-1 px-2.5 py-2 border-none rounded-lg bg-transparent text-text-muted text-[13px] font-medium cursor-pointer transition-all duration-200 flex items-center justify-center gap-1 whitespace-nowrap hover:text-text-primary', { '!bg-surface-card !text-accent !shadow-sm !font-semibold': keys[index].blacklist === 'whitelist' }]"
             @click="keys[index].blacklist = 'whitelist'" type="button"
           >
             <i class="mdi mdi-earth-plus"></i> Only on…
           </button>
         </div>
       </div>
-      <div class="toggle-row-inline">
-        <span class="toggle-label-sm">Active in form inputs</span>
+      <div class="flex items-center gap-2.5 px-3.5 py-2 bg-surface-card border border-border-default rounded-[10px] whitespace-nowrap shrink-0">
+        <span class="text-[13px] font-medium text-text-secondary">Active in form inputs</span>
         <button :class="['toggle', { on: keys[index].activeInInputs }]" @click="keys[index].activeInInputs = !keys[index].activeInInputs" type="button">
           <span class="toggle-knob"></span>
         </button>
@@ -253,7 +253,7 @@ function isBookmarkAction(action: string): boolean {
     </div>
     <textarea
       v-if="keys[index].blacklist && keys[index].blacklist !== 'false'"
-      class="field-textarea mono site-patterns"
+      class="field-textarea w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)] resize-y font-mono text-sm mt-2"
       v-model="keys[index].sites"
       rows="3"
       :placeholder="keys[index].blacklist === 'whitelist' ? 'Sites to activate on…\n*example.com*' : 'Sites to disable on…\n*example.com*'"

--- a/src/components/ShortcutRecorder.vue
+++ b/src/components/ShortcutRecorder.vue
@@ -106,9 +106,9 @@ function handleInputKeydown(e: KeyboardEvent) {
 </script>
 
 <template>
-  <div class="recorder-wrap">
+  <div class="flex gap-0 w-full">
     <input
-      class="field-input shortcut-input"
+      class="field-input shortcut-input peer !rounded-r-none !border-r-0 flex-1"
       type="text"
       placeholder="e.g. ctrl+shift+k"
       :value="modelValue"
@@ -117,84 +117,16 @@ function handleInputKeydown(e: KeyboardEvent) {
       :readonly="recording"
     />
     <button
-      :class="['record-btn', { recording }]"
+      :class="[
+        'flex items-center gap-1 px-4 border-[1.5px] border-border-default rounded-r-[10px] rounded-l-none bg-surface-elevated text-text-secondary text-[13px] font-semibold cursor-pointer transition-all duration-200 whitespace-nowrap hover:bg-surface-hover hover:text-text-primary hover:-translate-y-px peer-focus:border-accent',
+        { '!bg-danger-bg !border-danger-border !text-danger animate-[pulse-recording_1.5s_infinite_cubic-bezier(0.16,1,0.3,1)] shadow-[0_0_12px_rgba(239,68,68,0.4)]': recording },
+      ]"
       @click="recording ? stopRecording() : startRecording()"
       type="button"
       :title="recording ? 'Click to stop recording' : 'Record shortcut'"
     >
-      <i :class="recording ? 'mdi mdi-stop-circle' : 'mdi mdi-record-circle-outline'"></i>
-      <span class="record-text">{{ recording ? 'Stop' : 'Record' }}</span>
+      <i :class="[recording ? 'mdi mdi-stop-circle' : 'mdi mdi-record-circle-outline', 'text-sm']"></i>
+      <span class="hidden sm:inline">{{ recording ? 'Stop' : 'Record' }}</span>
     </button>
   </div>
 </template>
-
-<style scoped>
-.recorder-wrap {
-  display: flex;
-  gap: 0;
-  width: 100%;
-}
-
-.recorder-wrap .field-input {
-  border-radius: var(--radius-lg) 0 0 var(--radius-lg);
-  border-right: none;
-  flex: 1;
-}
-
-.recorder-wrap .field-input:focus + .record-btn {
-  border-color: var(--blue, #4361ee);
-}
-
-.record-btn {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 0 14px;
-  border: 1.5px solid var(--border, #e2e8f0);
-  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
-  background: var(--bg-elevated, #f8fafc);
-  color: var(--text-secondary, #64748b);
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-  white-space: nowrap;
-}
-
-.record-btn:hover {
-  background: var(--bg-hover, #f1f5f9);
-  color: var(--text, #1a1a2e);
-  border-color: var(--text-placeholder, #cbd5e1);
-  transform: translateY(-1px);
-}
-
-.record-btn.recording {
-  background: var(--danger-bg);
-  border-color: var(--danger-border);
-  color: var(--danger);
-  animation: pulse 1.5s infinite cubic-bezier(0.16, 1, 0.3, 1);
-  box-shadow: 0 0 12px rgba(239, 68, 68, 0.4);
-}
-
-.record-btn.recording:hover {
-  filter: brightness(0.95);
-}
-
-.record-btn .mdi {
-  font-size: 14px;
-}
-
-.record-btn.recording .mdi {
-  color: var(--danger);
-}
-
-@keyframes pulse {
-  0% { transform: scale(1); box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.4); }
-  50% { transform: scale(0.95); box-shadow: 0 0 0 6px rgba(239, 68, 68, 0); }
-  100% { transform: scale(1); box-shadow: 0 0 0 0 rgba(239, 68, 68, 0); }
-}
-
-@media (max-width: 600px) {
-  .record-text { display: none; }
-}
-</style>

--- a/src/entrypoints/options/App.vue
+++ b/src/entrypoints/options/App.vue
@@ -132,27 +132,27 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="app-wrapper">
+  <div class="min-h-screen flex flex-col">
     <!-- Header -->
-    <header class="app-header">
-      <div class="header-inner">
-        <div class="brand">
-          <img src="/images/icon_48.png" alt="Shortkeys" class="brand-icon" />
-          <span class="brand-text">Shortkeys</span>
+    <header class="app-header bg-white/80 backdrop-blur-[16px] backdrop-saturate-[180%] border-b border-border-light sticky top-0 z-10">
+      <div class="px-6 h-14 flex items-center justify-between">
+        <div class="flex items-center gap-2.5">
+          <img src="/images/icon_48.png" alt="Shortkeys" class="w-7 h-7" />
+          <span class="text-base font-bold text-text-primary tracking-tight">Shortkeys</span>
         </div>
-        <nav class="header-links">
-          <a href="https://chrome.google.com/webstore/detail/shortkeys-custom-keyboard/logpjaacgmcbpdkdchjiaagddngobkck/reviews" target="_blank">Review</a>
-          <a href="https://www.shortkeys.app/docs/" target="_blank">Docs</a>
-          <a href="https://github.com/mikecrittenden/shortkeys/issues" target="_blank">Support</a>
-          <a href="https://github.com/mikecrittenden/shortkeys" target="_blank">GitHub</a>
-          <div class="header-divider"></div>
-          <button class="header-btn" @click="undo" :disabled="!canUndo" title="Undo (Ctrl+Z)" type="button">
+        <nav class="flex items-center gap-1">
+          <a href="https://chrome.google.com/webstore/detail/shortkeys-custom-keyboard/logpjaacgmcbpdkdchjiaagddngobkck/reviews" target="_blank" class="text-text-muted text-[13px] font-medium no-underline px-2.5 py-1.5 rounded-lg transition-colors duration-150 hover:text-text-primary hover:bg-surface-hover">Review</a>
+          <a href="https://www.shortkeys.app/docs/" target="_blank" class="text-text-muted text-[13px] font-medium no-underline px-2.5 py-1.5 rounded-lg transition-colors duration-150 hover:text-text-primary hover:bg-surface-hover">Docs</a>
+          <a href="https://github.com/mikecrittenden/shortkeys/issues" target="_blank" class="text-text-muted text-[13px] font-medium no-underline px-2.5 py-1.5 rounded-lg transition-colors duration-150 hover:text-text-primary hover:bg-surface-hover">Support</a>
+          <a href="https://github.com/mikecrittenden/shortkeys" target="_blank" class="text-text-muted text-[13px] font-medium no-underline px-2.5 py-1.5 rounded-lg transition-colors duration-150 hover:text-text-primary hover:bg-surface-hover">GitHub</a>
+          <div class="header-divider w-px h-5 bg-border-default mx-1"></div>
+          <button class="header-btn w-8 h-8 flex items-center justify-center border border-border-default rounded-[10px] bg-surface-card text-text-secondary cursor-pointer text-base transition-all duration-150 hover:bg-surface-hover hover:text-text-primary disabled:opacity-30 disabled:cursor-default" @click="undo" :disabled="!canUndo" title="Undo (Ctrl+Z)" type="button">
             <i class="mdi mdi-undo"></i>
           </button>
-          <button class="header-btn" @click="redo" :disabled="!canRedo" title="Redo (Ctrl+Shift+Z)" type="button">
+          <button class="header-btn w-8 h-8 flex items-center justify-center border border-border-default rounded-[10px] bg-surface-card text-text-secondary cursor-pointer text-base transition-all duration-150 hover:bg-surface-hover hover:text-text-primary disabled:opacity-30 disabled:cursor-default" @click="redo" :disabled="!canRedo" title="Redo (Ctrl+Shift+Z)" type="button">
             <i class="mdi mdi-redo"></i>
           </button>
-          <button class="theme-toggle" @click="toggleTheme" :title="darkMode ? 'Switch to light mode' : 'Switch to dark mode'" type="button">
+          <button class="theme-toggle w-8 h-8 flex items-center justify-center border border-border-default rounded-[10px] bg-surface-card text-text-secondary cursor-pointer text-base transition-all duration-150 hover:bg-surface-hover hover:text-text-primary" @click="toggleTheme" :title="darkMode ? 'Switch to light mode' : 'Switch to dark mode'" type="button">
             <i :class="darkMode ? 'mdi mdi-white-balance-sunny' : 'mdi mdi-moon-waning-crescent'"></i>
           </button>
         </nav>
@@ -161,37 +161,37 @@ onUnmounted(() => {
 
     <!-- Toast -->
     <Transition name="toast">
-      <div v-if="snackMessage" :class="['toast', snackType === 'danger' ? 'toast-error' : 'toast-success']" @click="dismissSnack">
+      <div v-if="snackMessage" :class="['toast fixed bottom-8 right-8 z-[999] px-6 py-4 rounded-full text-[15px] font-semibold shadow-xl flex items-center gap-3 cursor-pointer backdrop-blur-[16px]', snackType === 'danger' ? 'toast-error bg-danger text-white' : 'toast-success bg-success text-white']" @click="dismissSnack">
         {{ snackMessage }}
-        <button v-if="snackAction" class="toast-action" @click.stop="snackAction.handler(); dismissSnack()" type="button">
+        <button v-if="snackAction" class="toast-action ml-3 px-4 py-1.5 bg-white/20 text-inherit border border-white/30 rounded-full cursor-pointer font-bold text-[13px] transition-all duration-200 hover:bg-white/35 hover:scale-105" @click.stop="snackAction.handler(); dismissSnack()" type="button">
           {{ snackAction.label }}
         </button>
       </div>
     </Transition>
 
-    <main class="app-main">
+    <main class="w-full p-6 flex-1">
       <!-- Tabs -->
-      <div class="tab-bar">
-        <button :class="['tab-btn', { active: activeTab === 0 }]" @click="activeTab = 0">
+      <div class="inline-flex gap-0.5 mb-6 bg-surface-elevated rounded-[10px] p-[3px] border border-border-light">
+        <button :class="['tab-btn px-5 py-2.5 border-none rounded-lg bg-transparent text-text-muted text-sm font-medium cursor-pointer transition-all duration-200 flex items-center justify-center gap-1.5 whitespace-nowrap hover:text-text-primary hover:bg-surface-hover', { 'active bg-surface-card !text-text-primary shadow-sm !font-semibold': activeTab === 0 }]" @click="activeTab = 0">
           <i class="mdi mdi-keyboard"></i> Shortcuts
         </button>
-        <button :class="['tab-btn', { active: activeTab === 1 }]" @click="activeTab = 1">
+        <button :class="['tab-btn px-5 py-2.5 border-none rounded-lg bg-transparent text-text-muted text-sm font-medium cursor-pointer transition-all duration-200 flex items-center justify-center gap-1.5 whitespace-nowrap hover:text-text-primary hover:bg-surface-hover', { 'active bg-surface-card !text-text-primary shadow-sm !font-semibold': activeTab === 1 }]" @click="activeTab = 1">
           <i class="mdi mdi-package-variant"></i> Packs
         </button>
-        <button :class="['tab-btn', { active: activeTab === 2 }]" @click="activeTab = 2">
+        <button :class="['tab-btn px-5 py-2.5 border-none rounded-lg bg-transparent text-text-muted text-sm font-medium cursor-pointer transition-all duration-200 flex items-center justify-center gap-1.5 whitespace-nowrap hover:text-text-primary hover:bg-surface-hover', { 'active bg-surface-card !text-text-primary shadow-sm !font-semibold': activeTab === 2 }]" @click="activeTab = 2">
           <i class="mdi mdi-import"></i> Import
         </button>
-        <button :class="['tab-btn', { active: activeTab === 3 }]" @click="activeTab = 3">
+        <button :class="['tab-btn px-5 py-2.5 border-none rounded-lg bg-transparent text-text-muted text-sm font-medium cursor-pointer transition-all duration-200 flex items-center justify-center gap-1.5 whitespace-nowrap hover:text-text-primary hover:bg-surface-hover', { 'active bg-surface-card !text-text-primary shadow-sm !font-semibold': activeTab === 3 }]" @click="activeTab = 3">
           <i class="mdi mdi-export"></i> Export
         </button>
-        <button :class="['tab-btn', { active: activeTab === 4 }]" @click="activeTab = 4">
+        <button :class="['tab-btn px-5 py-2.5 border-none rounded-lg bg-transparent text-text-muted text-sm font-medium cursor-pointer transition-all duration-200 flex items-center justify-center gap-1.5 whitespace-nowrap hover:text-text-primary hover:bg-surface-hover', { 'active bg-surface-card !text-text-primary shadow-sm !font-semibold': activeTab === 4 }]" @click="activeTab = 4">
           <i class="mdi mdi-chart-line"></i> Analytics
         </button>
       </div>
 
       <!-- Shortcuts Tab -->
-      <div v-show="activeTab === 0" class="tab-content">
-        <article v-if="needsUserScripts()" class="alert alert-warning">
+      <div v-show="activeTab === 0">
+        <article v-if="needsUserScripts()" class="alert alert-warning p-3.5 px-4.5 rounded-[14px] text-[13px] font-medium mb-5 leading-relaxed flex items-center gap-3 shadow-sm bg-warning-bg border-none border-l-[3px] border-l-warning-text text-warning-text">
           <i class="mdi mdi-alert-circle-outline"></i>
           <div>
             <strong>Allow User Scripts</strong> — In order for JavaScript actions to work, you must first allow User Scripts in your <a href="#" @click.prevent="openExtensionDetails">extension settings page</a>. Then come back and save your shortcuts.
@@ -199,41 +199,41 @@ onUnmounted(() => {
         </article>
 
         <!-- Stats bar -->
-        <div v-if="keys.length > 0 && !showOnboarding" class="stats-bar">
-          <div class="stats-bar-left">
-            <div class="stats-chips">
-              <span class="stat-chip">
+        <div v-if="keys.length > 0 && !showOnboarding" class="stats-bar flex justify-between items-center mb-4 gap-3 flex-wrap">
+          <div class="flex items-center gap-3 flex-wrap">
+            <div class="flex items-center gap-2 flex-wrap">
+              <span class="stat-chip flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[13px] font-semibold bg-surface-elevated text-text-secondary border border-border-light">
                 <i class="mdi mdi-keyboard"></i> {{ stats.total }} shortcut{{ stats.total !== 1 ? 's' : '' }}
               </span>
-              <span v-if="stats.disabled > 0" class="stat-chip stat-disabled">
+              <span v-if="stats.disabled > 0" class="stat-chip stat-disabled flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[13px] font-semibold !bg-warning-bg !text-warning-text border border-border-light">
                 <i class="mdi mdi-pause-circle-outline"></i> {{ stats.disabled }} disabled
               </span>
-              <span v-if="stats.withConflicts > 0" class="stat-chip stat-warn">
+              <span v-if="stats.withConflicts > 0" class="stat-chip stat-warn flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[13px] font-semibold !bg-danger-bg !text-danger-text border border-border-light">
                 <i class="mdi mdi-alert-outline"></i> {{ stats.withConflicts }} with conflicts
               </span>
             </div>
-            <div class="stats-actions">
-              <button class="btn btn-secondary btn-sm" @click="addShortcut">
+            <div class="flex items-center gap-2">
+              <button class="btn btn-secondary btn-sm px-3 py-1 text-xs bg-surface-card text-text-secondary border border-border-default rounded-lg font-semibold cursor-pointer transition-all duration-200 inline-flex items-center gap-1.5 hover:bg-surface-hover hover:text-text-primary" @click="addShortcut">
                 <i class="mdi mdi-plus"></i> Add shortcut
               </button>
-              <button class="btn btn-secondary btn-sm" @click="createNewGroup">
+              <button class="btn btn-secondary btn-sm px-3 py-1 text-xs bg-surface-card text-text-secondary border border-border-default rounded-lg font-semibold cursor-pointer transition-all duration-200 inline-flex items-center gap-1.5 hover:bg-surface-hover hover:text-text-primary" @click="createNewGroup">
                 <i class="mdi mdi-folder-plus-outline"></i> New group
               </button>
             </div>
           </div>
-          <div class="stats-bar-right">
-            <button class="density-toggle" @click="toggleDensity" :title="density === 'comfortable' ? 'Switch to condensed view' : 'Switch to comfortable view'" type="button">
+          <div class="flex items-center gap-2">
+            <button class="density-toggle w-8 h-8 flex items-center justify-center border border-border-default rounded-[10px] bg-surface-card text-text-secondary cursor-pointer text-base transition-all duration-150 hover:bg-surface-hover hover:text-text-primary" @click="toggleDensity" :title="density === 'comfortable' ? 'Switch to condensed view' : 'Switch to comfortable view'" type="button">
               <i :class="density === 'comfortable' ? 'mdi mdi-view-agenda-outline' : 'mdi mdi-view-headline'"></i>
             </button>
-            <div class="search-wrap">
-              <i class="mdi mdi-magnify search-icon"></i>
+            <div class="search-wrap relative flex-1 max-w-[280px]">
+              <i class="mdi mdi-magnify search-icon absolute left-2.5 top-1/2 -translate-y-1/2 text-text-muted text-base"></i>
               <input
-                class="search-input"
+                class="search-input w-full py-[7px] pl-8 pr-8 border-[1.5px] border-border-default rounded-lg text-[13px] text-text-primary bg-surface-card transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)] placeholder:text-text-placeholder"
                 type="text"
                 placeholder="Filter shortcuts…"
                 v-model="searchQuery"
               />
-              <button v-if="searchQuery" class="search-clear" @click="searchQuery = ''" type="button">
+              <button v-if="searchQuery" class="search-clear absolute right-1.5 top-1/2 -translate-y-1/2 bg-none border-none text-text-muted cursor-pointer p-0.5 text-sm" @click="searchQuery = ''" type="button">
                 <i class="mdi mdi-close"></i>
               </button>
             </div>
@@ -247,19 +247,19 @@ onUnmounted(() => {
             @finish="handleWizardFinish"
             @skip="completeOnboarding"
           />
-          <div v-else class="empty-state">
-          <div class="empty-state-icon">
+          <div v-else class="empty-state flex flex-col items-center justify-center py-20 px-6 text-center animate-empty-state">
+          <div class="text-[72px] text-accent mb-6 opacity-90 drop-shadow-[0_8px_16px_var(--blue-bg)] transition-transform duration-500">
             <i class="mdi mdi-keyboard-outline"></i>
           </div>
-          <h2 class="empty-state-title">No shortcuts yet</h2>
-          <p class="empty-state-desc">
+          <h2 class="text-2xl font-bold text-text-primary mb-3">No shortcuts yet</h2>
+          <p class="text-[15px] text-text-secondary max-w-[480px] leading-relaxed mb-8">
             Create custom keyboard shortcuts for 90+ browser actions — tab management, scrolling, navigation, running JavaScript, and more.
           </p>
-          <div class="empty-state-actions">
-            <button class="btn btn-primary" @click="addShortcut">
+          <div class="flex items-center gap-3">
+            <button class="btn btn-primary px-4 py-2 border-none rounded-lg text-[13px] font-semibold cursor-pointer transition-all duration-200 inline-flex items-center gap-1.5 tracking-[0.01em] bg-accent text-white shadow-[0_1px_3px_var(--blue-bg)] hover:bg-accent-hover hover:shadow-[0_4px_14px_var(--blue-bg)] hover:-translate-y-px active:translate-y-0" @click="addShortcut">
               <i class="mdi mdi-plus"></i> Create your first shortcut
             </button>
-            <button class="btn btn-secondary" @click="activeTab = 1">
+            <button class="btn btn-secondary px-4 py-2 rounded-lg text-[13px] font-semibold cursor-pointer transition-all duration-200 inline-flex items-center gap-1.5 tracking-[0.01em] bg-surface-card text-text-secondary border border-border-default hover:bg-surface-hover hover:text-text-primary" @click="activeTab = 1">
               <i class="mdi mdi-package-variant"></i> Browse shortcut packs
             </button>
           </div>
@@ -267,17 +267,17 @@ onUnmounted(() => {
         </template>
 
         <!-- Grouped shortcut rows -->
-        <div v-if="keys.length > 0 && !showOnboarding" class="shortcut-groups">
+        <div v-if="keys.length > 0 && !showOnboarding" class="shortcut-groups flex flex-col gap-4">
           <template v-for="group in groupNames" :key="group">
-          <div v-if="groupedIndices.has(group)" class="shortcut-group">
+          <div v-if="groupedIndices.has(group)" class="shortcut-group flex flex-col bg-surface-card border border-border-default rounded-[14px] shadow-sm transition-shadow duration-200">
             <!-- Group header -->
-            <div class="group-header" @dragover="onDragOverGroup($event, group)">
-              <button class="group-collapse" @click="toggleGroupCollapse(group)" type="button">
+            <div class="group-header flex items-center gap-2 py-3.5 px-4 bg-surface-elevated border-b border-border-light rounded-t-[14px]" @dragover="onDragOverGroup($event, group)">
+              <button class="bg-transparent border-none text-text-muted cursor-pointer p-0.5 text-sm transition-transform duration-150 hover:text-text-primary" @click="toggleGroupCollapse(group)" type="button">
                 <i :class="collapsedGroups.has(group) ? 'mdi mdi-chevron-right' : 'mdi mdi-chevron-down'"></i>
               </button>
               <template v-if="editingGroupName === group">
                 <input
-                  class="group-name-input"
+                  class="group-name-input font-bold text-text-primary text-xs uppercase tracking-[0.04em] bg-surface-input border border-border-default rounded-md px-2 py-1 outline-none focus:border-accent focus:shadow-[var(--focus-ring)]"
                   v-model="newGroupName"
                   @keydown.enter="finishRenameGroup(group)"
                   @blur="finishRenameGroup(group)"
@@ -287,33 +287,33 @@ onUnmounted(() => {
                 />
               </template>
               <template v-else>
-                <span class="group-name" @dblclick="startRenameGroup(group)">{{ group }}</span>
+                <span class="group-name font-bold text-text-primary select-none uppercase tracking-[0.04em] text-xs" @dblclick="startRenameGroup(group)">{{ group }}</span>
               </template>
-              <span class="group-count">{{ groupedIndices.get(group)?.length || 0 }}</span>
-              <i v-if="hasGroupSiteRules(group)" class="mdi mdi-earth group-site-indicator" title="Site rules active"></i>
-              <div class="group-actions">
-                <div class="group-menu-wrap">
-                  <button class="btn-icon btn-icon-sm" @click.stop="toggleGroupMenu(group)" title="Group options" type="button">
+              <span class="group-count text-xs font-semibold text-text-muted bg-surface-hover px-2 py-0.5 rounded-full leading-normal">{{ groupedIndices.get(group)?.length || 0 }}</span>
+              <i v-if="hasGroupSiteRules(group)" class="mdi mdi-earth text-accent text-xs" title="Site rules active"></i>
+              <div class="ml-auto flex items-center gap-1">
+                <div class="relative">
+                  <button class="btn-icon p-1.5 flex items-center justify-center border border-transparent rounded-lg bg-transparent text-text-muted cursor-pointer transition-all duration-150 text-base shrink-0 hover:bg-surface-hover hover:text-text-secondary hover:border-border-default text-sm" @click.stop="toggleGroupMenu(group)" title="Group options" type="button">
                     <i class="mdi mdi-dots-vertical"></i>
                   </button>
-                  <div v-if="groupMenuOpen === group" class="group-menu" @click="closeGroupMenus">
-                    <button class="group-menu-item" @click="startRenameGroup(group)">
+                  <div v-if="groupMenuOpen === group" class="group-menu absolute top-full right-0 mt-2 bg-surface-card border border-border-default rounded-[14px] shadow-xl min-w-[220px] z-20 overflow-hidden p-1.5 backdrop-blur-[12px]" @click="closeGroupMenus">
+                    <button class="group-menu-item flex items-center gap-2 w-full px-3 py-2.5 border-none bg-transparent rounded-lg text-[13px] font-medium text-text-primary cursor-pointer text-left transition-all duration-200 hover:bg-surface-hover hover:translate-x-0.5" @click="startRenameGroup(group)">
                       <i class="mdi mdi-pencil-outline"></i> Rename group
                     </button>
-                    <button class="group-menu-item" @click="toggleGroupEnabled(group)">
+                    <button class="group-menu-item flex items-center gap-2 w-full px-3 py-2.5 border-none bg-transparent rounded-lg text-[13px] font-medium text-text-primary cursor-pointer text-left transition-all duration-200 hover:bg-surface-hover hover:translate-x-0.5" @click="toggleGroupEnabled(group)">
                       <i :class="isGroupAllEnabled(group) ? 'mdi mdi-pause-circle-outline' : 'mdi mdi-play-circle-outline'"></i>
                       {{ isGroupAllEnabled(group) ? 'Disable all' : 'Enable all' }}
                     </button>
-                    <button class="group-menu-item" @click="toggleGroupSiteFilter(group)">
+                    <button class="group-menu-item flex items-center gap-2 w-full px-3 py-2.5 border-none bg-transparent rounded-lg text-[13px] font-medium text-text-primary cursor-pointer text-left transition-all duration-200 hover:bg-surface-hover hover:translate-x-0.5" @click="toggleGroupSiteFilter(group)">
                       <i class="mdi mdi-earth"></i> Site rules
                     </button>
-                    <button class="group-menu-item" @click="shareGroup(group)">
+                    <button class="group-menu-item flex items-center gap-2 w-full px-3 py-2.5 border-none bg-transparent rounded-lg text-[13px] font-medium text-text-primary cursor-pointer text-left transition-all duration-200 hover:bg-surface-hover hover:translate-x-0.5" @click="shareGroup(group)">
                       <i class="mdi mdi-share-variant-outline"></i> Share group
                     </button>
-                    <button class="group-menu-item" @click="publishToCommunity(group)">
+                    <button class="group-menu-item flex items-center gap-2 w-full px-3 py-2.5 border-none bg-transparent rounded-lg text-[13px] font-medium text-text-primary cursor-pointer text-left transition-all duration-200 hover:bg-surface-hover hover:translate-x-0.5" @click="publishToCommunity(group)">
                       <i class="mdi mdi-upload-outline"></i> Publish to community
                     </button>
-                    <button class="group-menu-item group-menu-danger" @click="deleteGroup(group)">
+                    <button class="group-menu-item group-menu-danger flex items-center gap-2 w-full px-3 py-2.5 border-none bg-transparent rounded-lg text-[13px] font-medium !text-danger cursor-pointer text-left transition-all duration-200 hover:!bg-danger-bg hover:translate-x-0.5" @click="deleteGroup(group)">
                       <i class="mdi mdi-delete-outline"></i> Delete group
                     </button>
                   </div>
@@ -323,22 +323,22 @@ onUnmounted(() => {
 
             <!-- Group site rules panel -->
             <Transition name="expand">
-              <div v-if="expandedGroupSiteFilter === group" class="group-site-panel">
-                <div class="group-site-fields">
-                  <div class="group-site-field">
-                    <label class="group-site-label"><i class="mdi mdi-earth-plus"></i> Only activate on</label>
+              <div v-if="expandedGroupSiteFilter === group" class="group-site-panel px-4 py-3 border-b border-border-light bg-surface-elevated">
+                <div class="group-site-fields flex gap-3">
+                  <div class="group-site-field flex-1 min-w-0">
+                    <label class="group-site-label block text-xs font-semibold text-text-secondary mb-1"><i class="mdi mdi-earth-plus"></i> Only activate on</label>
                     <textarea
-                      class="field-textarea mono group-site-textarea"
+                      class="field-textarea group-site-textarea w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)] resize-y !text-xs !p-[6px_10px] font-mono"
                       v-model="groupSettings[group].activateOn"
                       @blur="persistGroupSettings()"
                       rows="2"
                       placeholder="e.g. gmail.com&#10;*github.com/myorg*"
                     ></textarea>
                   </div>
-                  <div class="group-site-field">
-                    <label class="group-site-label"><i class="mdi mdi-earth-minus"></i> Deactivate on</label>
+                  <div class="group-site-field flex-1 min-w-0">
+                    <label class="group-site-label block text-xs font-semibold text-text-secondary mb-1"><i class="mdi mdi-earth-minus"></i> Deactivate on</label>
                     <textarea
-                      class="field-textarea mono group-site-textarea"
+                      class="field-textarea group-site-textarea w-full px-3 py-[9px] border-[1.5px] border-border-default rounded-lg text-sm text-text-primary bg-surface-input transition-[border-color,box-shadow] duration-150 focus:outline-none focus:border-accent focus:shadow-[var(--focus-ring)] resize-y !text-xs !p-[6px_10px] font-mono"
                       v-model="groupSettings[group].deactivateOn"
                       @blur="persistGroupSettings()"
                       rows="2"
@@ -346,7 +346,7 @@ onUnmounted(() => {
                     ></textarea>
                   </div>
                 </div>
-                <p class="group-site-hint">
+                <p class="group-site-hint text-[11px] text-text-muted mt-2">
                   Applies to all shortcuts in this group. Individual shortcuts can still override with their own site filter.
                   Simple domains like <code>gmail.com</code> work automatically, or use <code>*</code> as a wildcard.
                   If both fields are set, the URL must match "activate" and not match "deactivate".
@@ -355,21 +355,21 @@ onUnmounted(() => {
             </Transition>
 
             <!-- Shortcuts in this group -->
-            <div class="shortcut-list" v-show="!collapsedGroups.has(group)">
+            <div class="shortcut-list flex flex-col gap-px p-1.5 bg-border-light" v-show="!collapsedGroups.has(group)">
               <div
                 v-for="index in (groupedIndices.get(group) || [])"
                 :key="keys[index].id"
-                :class="['shortcut-card', { disabled: keys[index].enabled === false, dragging: dragIndex === index, expanded: expandedRow === index }]"
+                :class="['shortcut-card group bg-surface-card rounded-lg transition-all duration-150 relative hover:bg-surface-elevated', { 'disabled opacity-45': keys[index].enabled === false, 'dragging': dragIndex === index, 'expanded border-l-[3px] border-l-accent rounded-[10px] shadow-sm my-1 bg-surface-card': expandedRow === index }]"
                 :draggable="handleActive"
                 @dragstart="onDragStart($event, index)"
                 @dragover="onDragOver($event, index)"
                 @dragend="onDragEnd"
               >
                 <!-- Editable label above the card -->
-                <div class="shortcut-header">
-                  <i class="mdi mdi-drag-vertical drag-handle" title="Drag to reorder" @mousedown="onHandleMouseDown"></i>
+                <div class="shortcut-header flex items-center gap-1 px-3 pt-1.5">
+                  <i class="mdi mdi-drag-vertical drag-handle text-text-placeholder text-base cursor-grab p-0.5 shrink-0 transition-colors duration-150 opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:text-text-muted" title="Drag to reorder" @mousedown="onHandleMouseDown"></i>
                   <input
-                    class="shortcut-label-title"
+                    class="shortcut-label-title flex-1 min-w-0 border-none bg-transparent text-xs font-medium text-text-muted outline-none px-1 py-0.5 rounded-[5px] transition-all duration-150 placeholder:text-text-placeholder focus:text-text-primary focus:bg-surface-input focus:shadow-[var(--focus-ring)]"
                     type="text"
                     placeholder="Untitled shortcut"
                     v-model="keys[index].label"
@@ -383,20 +383,20 @@ onUnmounted(() => {
                     <span class="toggle-knob"></span>
                   </button>
                 </div>
-                <div class="shortcut-row">
-                  <div class="field-group shortcut-col">
-                    <label class="field-label">Shortcut</label>
+                <div class="shortcut-row flex items-end gap-3 px-4 pt-2.5 pb-3">
+                  <div class="field-group shortcut-col w-80 shrink-0 grow-0 basis-80 flex flex-col gap-1 min-w-0">
+                    <label class="field-label text-[11px] font-bold uppercase tracking-[0.06em] text-text-placeholder">Shortcut</label>
                     <ShortcutRecorder
                       :modelValue="keys[index].key"
                       @update:modelValue="keys[index].key = $event"
                     />
                   </div>
-                  <div class="field-group behavior-col">
-                    <div class="field-label-row">
-                      <label class="field-label">Behavior</label>
+                  <div class="field-group behavior-col flex-1 min-w-0 flex flex-col gap-1">
+                    <div class="field-label-row flex items-center justify-between gap-2">
+                      <label class="field-label text-[11px] font-bold uppercase tracking-[0.06em] text-text-placeholder">Behavior</label>
                       <button
                         v-if="keys[index].action && keys[index].action !== 'macro'"
-                        class="btn-chain-link"
+                        class="text-accent text-[11px] font-medium bg-transparent border-none cursor-pointer flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200 hover:underline"
                         @click="convertToMacro(keys[index], index)"
                         type="button"
                       >
@@ -410,19 +410,19 @@ onUnmounted(() => {
                       placeholder="Choose action…"
                     />
                   </div>
-                  <div class="shortcut-actions">
-                    <button class="btn-icon" @click="toggleDetails(index)" :title="expandedRow === index ? 'Collapse' : 'Settings'">
+                  <div class="shortcut-actions flex items-center gap-0.5 shrink-0 pb-px">
+                    <button class="btn-icon p-1.5 flex items-center justify-center border border-transparent rounded-lg bg-transparent text-text-muted cursor-pointer transition-all duration-150 text-base shrink-0 hover:bg-surface-hover hover:text-text-secondary hover:border-border-default" @click="toggleDetails(index)" :title="expandedRow === index ? 'Collapse' : 'Settings'">
                       <i :class="expandedRow === index ? 'mdi mdi-chevron-up' : 'mdi mdi-cog-outline'"></i>
                     </button>
-                    <button class="btn-icon btn-delete" @click="deleteShortcut(index)" title="Delete">
+                    <button class="btn-icon btn-delete p-1.5 flex items-center justify-center border border-transparent rounded-lg bg-transparent text-text-muted cursor-pointer transition-all duration-150 text-base shrink-0 hover:!bg-danger-bg hover:!text-danger hover:!border-danger-border" @click="deleteShortcut(index)" title="Delete">
                       <i class="mdi mdi-close"></i>
                     </button>
                   </div>
                 </div>
 
             <!-- Conflict warnings -->
-            <div v-if="getConflicts(index).length" class="conflict-warnings">
-              <div v-for="(c, ci) in getConflicts(index)" :key="ci" :class="['conflict-pill', c.type]">
+            <div v-if="getConflicts(index).length" class="conflict-warnings flex flex-wrap gap-1.5 px-4 pb-2.5">
+              <div v-for="(c, ci) in getConflicts(index)" :key="ci" :class="['conflict-pill inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium', c.type === 'browser' ? 'browser bg-warning-bg text-warning-text border border-warning-border' : 'duplicate bg-danger-bg text-danger-text border border-danger-border']">
                 <i :class="c.type === 'browser' ? 'mdi mdi-alert-outline' : 'mdi mdi-content-duplicate'"></i>
                 {{ c.message }}
               </div>
@@ -435,7 +435,7 @@ onUnmounted(() => {
           </div>
             </div>
             <!-- Add shortcut to this group -->
-            <button class="btn-add-to-group" @click="addShortcutToGroup(group)" type="button" v-show="!collapsedGroups.has(group)">
+            <button class="btn-add-to-group flex items-center justify-center gap-1 py-2 bg-transparent border-none border-t border-dashed border-t-border-light rounded-b-[10px] text-text-muted text-xs font-medium cursor-pointer transition-all duration-150 hover:bg-surface-elevated hover:text-text-secondary" @click="addShortcutToGroup(group)" type="button" v-show="!collapsedGroups.has(group)">
               <i class="mdi mdi-plus"></i> Add shortcut
             </button>
           </div>
@@ -443,8 +443,8 @@ onUnmounted(() => {
         </div>
 
         <Transition name="toast">
-          <div v-if="keys.length > 0 && !showOnboarding && dirty" class="action-bar">
-            <button class="btn btn-primary" @click="saveShortcuts">
+          <div v-if="keys.length > 0 && !showOnboarding && dirty" class="action-bar flex justify-center items-center mt-12 sticky bottom-6 z-50 pointer-events-none">
+            <button class="btn btn-primary pointer-events-auto px-7 py-3 text-sm rounded-full shadow-[0_4px_20px_rgba(0,0,0,0.15),0_1px_3px_rgba(0,0,0,0.1)] border-none font-semibold cursor-pointer transition-all duration-200 inline-flex items-center gap-1.5 bg-accent text-white hover:bg-accent-hover hover:-translate-y-px active:translate-y-0" @click="saveShortcuts">
               <i class="mdi mdi-content-save"></i> Save shortcuts
             </button>
           </div>
@@ -452,12 +452,12 @@ onUnmounted(() => {
       </div>
 
       <!-- Packs Tab -->
-      <div v-show="activeTab === 1" class="tab-content">
+      <div v-show="activeTab === 1">
         <PacksTab />
       </div>
 
       <!-- Import Tab -->
-      <div v-show="activeTab === 2" class="tab-content">
+      <div v-show="activeTab === 2">
         <ImportTab />
       </div>
 
@@ -467,12 +467,12 @@ onUnmounted(() => {
       <JsWarningDialog />
 
       <!-- Export Tab -->
-      <div v-show="activeTab === 3" class="tab-content">
+      <div v-show="activeTab === 3">
         <ExportTab />
       </div>
 
       <!-- Analytics Tab -->
-      <div v-show="activeTab === 4" class="tab-content">
+      <div v-show="activeTab === 4">
         <AnalyticsTab />
       </div>
     </main>
@@ -480,1845 +480,3 @@ onUnmounted(() => {
   </div>
 </template>
 
-<style>
-/* ── Reset & base ── */
-*, *::before, *::after { box-sizing: border-box; }
-
-:root {
-  /* Surface colors — warm neutral palette */
-  --bg: #f8f9fb;
-  --bg-card: #ffffff;
-  --bg-elevated: #f3f4f8;
-  --bg-input: #ffffff;
-  --bg-hover: #eef0f5;
-  
-  /* Text — stronger hierarchy */
-  --text: #111827;
-  --text-secondary: #4b5563;
-  --text-muted: #9ca3af;
-  --text-placeholder: #d1d5db;
-  
-  /* Borders — softer */
-  --border: #e5e7eb;
-  --border-light: #f0f1f4;
-  
-  /* Accent — deeper indigo instead of generic blue */
-  --blue: #4f46e5;
-  --blue-hover: #4338ca;
-  --blue-bg: rgba(79,70,229,0.1);
-  
-  /* Surface shadows — base values used in composed shadows */
-  --shadow: rgba(0,0,0,0.04);
-  --shadow-hover: rgba(0,0,0,0.08);
-
-  /* Semantic colors */
-  --danger: #ef4444;
-  --danger-hover: #dc2626;
-  --danger-bg: #fef2f2;
-  --danger-border: #fecaca;
-  --danger-text: #991b1b;
-  --success: #059669;
-  --success-hover: #047857;
-  --success-bg: #ecfdf5;
-  --success-border: #a7f3d0;
-  --success-text: #065f46;
-  --warning-bg: #fffbeb;
-  --warning-border: #fde68a;
-  --warning-text: #92400e;
-  --info-bg: #eef2ff;
-  --info-border: #c7d2fe;
-  --info-text: #3730a3;
-
-  /* Spacing scale */
-  --space-xs: 4px;
-  --space-sm: 8px;
-  --space-md: 12px;
-  --space-lg: 16px;
-  --space-xl: 24px;
-  --space-2xl: 32px;
-  --space-3xl: 48px;
-
-  /* Radius scale — slightly larger for modern feel */
-  --radius-sm: 5px;
-  --radius-md: 8px;
-  --radius-lg: 10px;
-  --radius-xl: 14px;
-  --radius-2xl: 18px;
-  --radius-full: 9999px;
-
-  /* Shadow scale — layered, premium */
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.04), 0 1px 3px rgba(0,0,0,0.06);
-  --shadow-md: 0 2px 4px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.06);
-  --shadow-lg: 0 4px 8px rgba(0,0,0,0.04), 0 12px 32px rgba(0,0,0,0.08);
-  --shadow-xl: 0 8px 16px rgba(0,0,0,0.06), 0 24px 56px rgba(0,0,0,0.12);
-
-  /* Focus ring */
-  --focus-ring: 0 0 0 3px rgba(79,70,229,0.15);
-}
-
-[data-theme="dark"] {
-  --bg: #0c0f1a;
-  --bg-card: #161b2e;
-  --bg-elevated: #1c2237;
-  --bg-input: #0c0f1a;
-  --bg-hover: #242b42;
-  --text: #e8eaf0;
-  --text-secondary: #8b92a8;
-  --text-muted: #565e78;
-  --text-placeholder: #3d4560;
-  --border: #2a3150;
-  --border-light: #1e2440;
-  --blue: #6366f1;
-  --blue-hover: #818cf8;
-  --blue-bg: rgba(99,102,241,0.15);
-  --shadow: rgba(0,0,0,0.25);
-  --shadow-hover: rgba(0,0,0,0.35);
-
-  /* Semantic colors — dark */
-  --danger: #f87171;
-  --danger-hover: #ef4444;
-  --danger-bg: rgba(239,68,68,0.12);
-  --danger-border: rgba(239,68,68,0.25);
-  --danger-text: #fca5a5;
-  --success: #34d399;
-  --success-hover: #10b981;
-  --success-bg: rgba(52,211,153,0.12);
-  --success-border: rgba(52,211,153,0.25);
-  --success-text: #6ee7b7;
-  --warning-bg: rgba(245,158,11,0.08);
-  --warning-border: rgba(245,158,11,0.15);
-  --warning-text: #f59e0b;
-  --info-bg: rgba(99,102,241,0.12);
-  --info-border: rgba(99,102,241,0.25);
-  --info-text: #a5b4fc;
-
-  /* Shadow scale — dark */
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.2), 0 1px 3px rgba(0,0,0,0.15);
-  --shadow-md: 0 2px 4px rgba(0,0,0,0.2), 0 4px 12px rgba(0,0,0,0.2);
-  --shadow-lg: 0 4px 8px rgba(0,0,0,0.2), 0 12px 32px rgba(0,0,0,0.25);
-  --shadow-xl: 0 8px 16px rgba(0,0,0,0.25), 0 24px 56px rgba(0,0,0,0.35);
-
-  /* Focus ring — dark */
-  --focus-ring: 0 0 0 3px rgba(99,102,241,0.25);
-}
-
-[data-theme="dark"] .app-header {
-  background: rgba(12,15,26,0.88);
-}
-
-html, body {
-  margin: 0;
-  padding: 0;
-  background: var(--bg);
-  background-image: radial-gradient(circle at 50% 0%, var(--bg-card) 0%, transparent 60%);
-  background-attachment: fixed;
-  color: var(--text);
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-  font-size: 14px;
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a { color: var(--blue); text-decoration: none; }
-a:hover { text-decoration: underline; }
-
-/* ── Layout ── */
-.app-wrapper {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-}
-
-.app-header {
-  background: rgba(255,255,255,0.8);
-  backdrop-filter: blur(16px) saturate(180%);
-  -webkit-backdrop-filter: blur(16px) saturate(180%);
-  border-bottom: 1px solid var(--border-light);
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}
-
-.header-inner {
-  max-width: 1120px;
-  margin: 0 auto;
-  padding: 0 var(--space-xl);
-  height: 56px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.brand {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.brand-icon { width: 28px; height: 28px; }
-
-.brand-text {
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--text);
-  letter-spacing: -0.4px;
-}
-
-.header-links {
-  display: flex;
-  gap: 16px;
-  align-items: center;
-}
-
-.header-links a {
-  color: var(--text-secondary);
-  font-size: 13px;
-  font-weight: 500;
-  transition: color 0.15s;
-}
-
-.header-links a:hover { color: var(--blue); text-decoration: none; }
-
-.theme-toggle {
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--bg-card);
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-size: 16px;
-  transition: all 0.15s;
-}
-
-.theme-toggle:hover { background: var(--bg-hover); color: var(--text); }
-
-.header-btn {
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--bg-card);
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-size: 16px;
-  transition: all 0.15s;
-}
-.header-btn:hover:not(:disabled) { background: var(--bg-hover); color: var(--text); }
-.header-btn:disabled { opacity: 0.3; cursor: default; }
-
-.header-divider {
-  width: 1px;
-  height: 20px;
-  background: var(--border);
-  margin: 0 4px;
-}
-
-.app-main {
-  max-width: 1120px;
-  width: 100%;
-  margin: 0 auto;
-  padding: var(--space-xl);
-  flex: 1;
-}
-
-/* ── Tabs ── */
-.tab-bar {
-  display: inline-flex;
-  gap: 2px;
-  margin-bottom: var(--space-xl);
-  background: var(--bg-elevated);
-  border-radius: var(--radius-lg);
-  padding: 3px;
-  border: 1px solid var(--border-light);
-}
-
-.tab-btn {
-  padding: 8px 18px;
-  border: none;
-  border-radius: var(--radius-md);
-  background: transparent;
-  color: var(--text-muted);
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  letter-spacing: 0.01em;
-  white-space: nowrap;
-}
-
-.tab-btn:hover { color: var(--text); background: var(--bg-hover); }
-.tab-btn.active { 
-  background: var(--bg-card); 
-  color: var(--text); 
-  box-shadow: var(--shadow-sm);
-  font-weight: 600; 
-}
-.tab-btn .mdi { font-size: 16px; }
-
-.tab-content { animation: fadeIn 0.15s ease; }
-@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
-
-/* ── Stats bar ── */
-.stats-bar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: var(--space-lg);
-  gap: var(--space-md);
-  flex-wrap: wrap;
-}
-
-.stats-bar-left {
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-  flex-wrap: wrap;
-}
-
-.stats-chips {
-  display: flex;
-  gap: var(--space-sm);
-  flex-shrink: 0;
-}
-
-.stats-actions {
-  display: flex;
-  gap: 6px;
-}
-
-.stats-bar-right {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-}
-
-.stat-chip {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  padding: 4px 10px;
-  border-radius: var(--radius-full);
-  font-size: 12px;
-  font-weight: 600;
-  background: var(--bg-elevated);
-  color: var(--text-secondary);
-  border: 1px solid var(--border-light);
-}
-
-.stat-chip .mdi { font-size: 14px; }
-.stat-disabled { background: var(--warning-bg); color: var(--warning-text); }
-.stat-warn { background: var(--danger-bg); color: var(--danger-text); }
-
-.search-wrap {
-  position: relative;
-  flex: 1;
-  max-width: 280px;
-}
-
-.search-icon {
-  position: absolute;
-  left: 10px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--text-muted);
-  font-size: 16px;
-}
-
-.search-input {
-  width: 100%;
-  padding: 7px 32px 7px 32px;
-  border: 1.5px solid var(--border);
-  border-radius: var(--radius-md);
-  font-size: 13px;
-  color: var(--text);
-  background: var(--bg-card);
-  transition: border-color 0.15s, box-shadow 0.15s;
-}
-
-.search-input:focus { outline: none; border-color: var(--blue); box-shadow: var(--focus-ring); }
-.search-input::placeholder { color: var(--text-placeholder); }
-
-.search-clear {
-  position: absolute;
-  right: 6px;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  padding: 2px;
-  font-size: 14px;
-}
-
-/* ── Shortcut cards ── */
-.shortcut-groups {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-lg);
-}
-
-.shortcut-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
-  box-shadow: var(--shadow-sm);
-  transition: box-shadow 0.2s ease;
-  overflow: visible;
-}
-
-.shortcut-group[style*="display: none"] + .shortcut-group { margin-top: 0; }
-
-.group-header {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  padding: 12px 16px;
-  background: var(--bg-elevated);
-  border-bottom: 1px solid var(--border-light);
-  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
-}
-
-.shortcut-group .shortcut-list { border-top: none; }
-
-.group-collapse {
-  background: none;
-  border: none;
-  padding: 2px;
-  cursor: pointer;
-  color: var(--text-muted);
-  font-size: 18px;
-  display: flex;
-  align-items: center;
-  transition: color 0.15s;
-}
-
-.group-collapse:hover { color: var(--text-secondary); }
-
-.group-name {
-  font-size: 13px;
-  font-weight: 700;
-  color: var(--text);
-  cursor: default;
-  user-select: none;
-  letter-spacing: -0.01em;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  font-size: 11px;
-}
-
-.group-name-input {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text);
-  border: 1px solid var(--blue);
-  border-radius: var(--radius-sm);
-  padding: 2px 6px;
-  outline: none;
-  background: var(--bg-card);
-  box-shadow: var(--focus-ring);
-}
-
-.group-count {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--text-muted);
-  background: var(--bg-hover);
-  padding: 1px 7px;
-  border-radius: var(--radius-full);
-  line-height: 1.5;
-}
-
-.group-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-  margin-left: auto;
-}
-
-.btn-icon-sm { width: 28px; height: 28px; font-size: 14px; }
-
-.group-menu-wrap {
-  position: relative;
-}
-
-.group-menu {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  margin-top: 8px;
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
-  box-shadow: var(--shadow-xl);
-  min-width: 220px;
-  z-index: 20;
-  overflow: hidden;
-  padding: 6px;
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-}
-
-.group-menu-item {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  width: 100%;
-  padding: 10px 12px;
-  border: none;
-  background: transparent;
-  border-radius: var(--radius-md);
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--text);
-  cursor: pointer;
-  text-align: left;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.group-menu-item:hover { 
-  background: var(--bg-hover); 
-  transform: translateX(2px);
-}
-.group-menu-item .mdi { font-size: 16px; color: var(--text-secondary); }
-.group-menu-danger { color: var(--danger); }
-.group-menu-danger .mdi { color: var(--danger); }
-.group-menu-danger:hover { background: var(--danger-bg); }
-
-.btn-add-to-group {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-xs);
-  padding: 8px;
-  background: transparent;
-  border: none;
-  border-top: 1px dashed var(--border-light);
-  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.btn-add-to-group:hover { background: var(--bg-elevated); color: var(--text-secondary); }
-.shortcut-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  padding: 6px;
-  background: var(--border-light);
-}
-
-.shortcut-card {
-  background: var(--bg-card);
-  border-radius: var(--radius-md);
-  box-shadow: none;
-  border: none;
-  transition: all 0.15s ease;
-  margin-bottom: 0;
-  position: relative;
-}
-
-.shortcut-card:last-child { margin-bottom: 0; }
-.shortcut-card:hover { background: var(--bg-elevated); }
-.shortcut-card.disabled { opacity: 0.45; }
-.shortcut-card.dragging { opacity: 0.4; box-shadow: var(--shadow-lg); outline: 2px solid var(--blue); outline-offset: -2px; }
-.shortcut-card.expanded {
-  border-left: 3px solid var(--blue);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-sm);
-  margin: 4px 0;
-  background: var(--bg-card);
-}
-.shortcut-card.expanded:hover { background: var(--bg-card); }
-
-.shortcut-header {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-  padding: 6px 12px 0 6px;
-}
-
-.drag-handle {
-  color: var(--text-placeholder);
-  font-size: 16px;
-  cursor: grab;
-  padding: 2px;
-  flex-shrink: 0;
-  transition: color 0.15s;
-  opacity: 0;
-}
-
-.shortcut-card:hover .drag-handle { opacity: 0.5; }
-.drag-handle:hover { color: var(--text-muted); opacity: 1 !important; }
-.shortcut-card.dragging .drag-handle { cursor: grabbing; opacity: 1 !important; }
-
-.shortcut-label-title {
-  flex: 1;
-  min-width: 0;
-  border: none;
-  background: transparent;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--text-muted);
-  outline: none;
-  padding: 2px 4px;
-  border-radius: var(--radius-sm);
-  transition: all 0.15s;
-}
-
-.shortcut-label-title::placeholder { color: var(--text-placeholder); }
-.shortcut-label-title:focus { color: var(--text); background: var(--bg-input); box-shadow: var(--focus-ring); }
-
-.shortcut-row {
-  display: flex;
-  align-items: flex-end;
-  gap: var(--space-sm);
-  padding: 6px 12px 10px;
-}
-
-.field-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
-  min-width: 0;
-}
-
-.shortcut-col { width: 320px; flex: 0 0 320px; }
-.behavior-col { flex: 1; min-width: 0; }
-
-.field-label {
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-placeholder);
-}
-
-.field-input, .field-select, .field-textarea {
-  width: 100%;
-  padding: 7px 11px;
-  border: 1.5px solid var(--border);
-  border-radius: var(--radius-md);
-  font-size: 13px;
-  color: var(--text);
-  background: var(--bg-input);
-  transition: border-color 0.15s, box-shadow 0.15s;
-}
-
-.field-input:focus, .field-select:focus, .field-textarea:focus {
-  outline: none;
-  border-color: var(--blue);
-  box-shadow: var(--focus-ring);
-}
-
-.field-textarea { resize: vertical; }
-.mono { font-family: 'SF Mono', Menlo, Consolas, monospace; font-size: 13px; }
-
-.shortcut-input { font-family: 'SF Mono', Menlo, Consolas, monospace; font-weight: 500; }
-
-.shortcut-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-  flex-shrink: 0;
-  align-self: flex-end;
-}
-
-.btn-icon {
-  padding: 6px;
-  box-sizing: border-box;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid transparent;
-  border-radius: var(--radius-md);
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-  transition: all 0.15s;
-  font-size: 16px;
-  flex-shrink: 0;
-}
-
-.btn-icon:hover { background: var(--bg-hover); color: var(--text-secondary); border-color: var(--border); }
-.btn-delete:hover { background: var(--danger-bg); color: var(--danger); border-color: var(--danger-border); }
-.shortcut-header .toggle { flex-shrink: 0; }
-
-
-/* ── Details panel ── */
-.shortcut-details {
-  border-top: 1px solid var(--border-light);
-  padding: 12px 16px;
-  background: var(--bg-elevated);
-}
-
-/* ── Conflict warnings ── */
-.conflict-warnings {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  padding: 0 16px 10px;
-}
-
-.conflict-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-xs);
-  padding: 4px 10px;
-  border-radius: var(--radius-full);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.conflict-pill .mdi { font-size: 14px; }
-
-.conflict-pill.browser {
-  background: var(--warning-bg);
-  color: var(--warning-text);
-  border: 1px solid var(--warning-border);
-}
-
-.conflict-pill.duplicate {
-  background: var(--danger-bg);
-  color: var(--danger-text);
-  border: 1px solid var(--danger-border);
-}
-
-.details-section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
-}
-
-.details-section:empty { display: none; }
-
-.detail-row {
-  display: flex;
-  gap: var(--space-md);
-  align-items: flex-end;
-}
-
-.detail-row > .toggle-row-inline {
-  margin-bottom: 1px;
-}
-
-.flex-1 { flex: 1; min-width: 0; }
-
-/* Activation bar: toggle + filter side by side */
-.activation-bar {
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-  margin-top: 12px;
-  padding-top: 12px;
-  border-top: 1px solid var(--border-light);
-}
-
-.site-filter-inline { flex: 1; }
-.site-patterns { margin-top: 8px; }
-
-.toggle-row-inline {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 14px;
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-.toggle-label-sm { font-size: 13px; font-weight: 500; color: var(--text-secondary); }
-
-.detail-field {
-  margin-bottom: 0;
-}
-
-.detail-field label {
-  display: block;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--text-secondary);
-  margin-bottom: 4px;
-}
-
-.hint { font-weight: 400; color: var(--text-muted); }
-.hint-link { font-weight: 400; color: var(--blue); font-size: 12px; }
-
-/* ── Macro builder ── */
-.macro-builder {
-  width: 100%;
-}
-
-.macro-label {
-  display: block;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  margin-bottom: 8px;
-}
-
-.macro-label i {
-  margin-right: 4px;
-}
-
-.macro-steps {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-bottom: 8px;
-}
-
-.macro-step {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  padding: 6px 8px;
-  background: var(--bg-card, #fff);
-  border: 1px solid var(--border, #e0e0e0);
-  border-radius: var(--radius-lg);
-  flex-wrap: wrap;
-}
-
-.macro-step-num {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-muted);
-  min-width: 18px;
-  text-align: center;
-}
-
-.macro-step-action {
-  flex: 1;
-  min-width: 0;
-}
-
-.macro-step-delay {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-  flex-shrink: 0;
-}
-
-.delay-input {
-  width: 70px !important;
-  text-align: right;
-  padding: 7px 8px !important;
-  font-size: 12px !important;
-}
-
-.delay-unit {
-  font-size: 11px;
-  color: var(--text-muted);
-}
-
-.macro-step-controls {
-  display: flex;
-  gap: 2px;
-  flex-shrink: 0;
-}
-
-.macro-step-controls .btn-icon {
-  width: 26px !important;
-  height: 26px !important;
-  font-size: 14px !important;
-}
-.macro-step-code {
-  width: 100%;
-  margin-top: var(--space-xs);
-}
-
-.btn-add-step {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-xs);
-  padding: 6px 14px;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--blue, #4361ee);
-  background: transparent;
-  border: 1px dashed var(--blue, #4361ee);
-  border-radius: var(--radius-lg);
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.btn-add-step:hover {
-  background: var(--bg-hover, rgba(67, 97, 238, 0.06));
-}
-
-.macro-empty {
-  font-size: 13px;
-  color: var(--text-muted);
-  margin: 0;
-  padding: 8px 0;
-}
-
-.field-label-row {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--space-sm);
-}
-
-.btn-chain-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  padding: 0;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--blue, #4361ee);
-  background: none;
-  border: none;
-  cursor: pointer;
-  opacity: 0.6;
-  transition: opacity 0.15s;
-  white-space: nowrap;
-}
-
-.btn-chain-link:hover {
-  opacity: 1;
-}
-
-.btn-chain-link i {
-  font-size: 12px;
-}
-
-/* ── Toggle switch ── */
-.toggle {
-  position: relative;
-  width: 44px;
-  height: 24px;
-  border-radius: var(--radius-full);
-  border: none;
-  background: var(--border);
-  cursor: pointer;
-  transition: background 0.25s cubic-bezier(0.16, 1, 0.3, 1);
-  flex-shrink: 0;
-  padding: 0;
-}
-
-.toggle.on { background: var(--blue); }
-
-.toggle-knob {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: #fff;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.15), 0 1px 1px rgba(0,0,0,0.06);
-  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.toggle.on .toggle-knob { transform: translateX(20px); }
-
-/* Small toggle variant (enable/disable) */
-.toggle.toggle-sm { width: 36px; height: 20px; border-radius: var(--radius-full); }
-.toggle.toggle-sm .toggle-knob { width: 16px; height: 16px; top: 2px; left: 2px; }
-.toggle.toggle-sm.on .toggle-knob { transform: translateX(16px); }
-
-/* ── Segmented control ── */
-.segmented {
-  display: flex;
-  background: var(--bg-hover);
-  border-radius: var(--radius-lg);
-  padding: 3px;
-  gap: 2px;
-  border: 1px solid var(--border-light);
-}
-
-.seg-btn {
-  flex: 1;
-  padding: 7px 8px;
-  border: none;
-  border-radius: var(--radius-md);
-  background: transparent;
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-xs);
-  white-space: nowrap;
-}
-
-.seg-btn:hover { color: var(--text); }
-.seg-btn.active { background: var(--bg-card); color: var(--blue); box-shadow: var(--shadow-sm); font-weight: 600; }
-.seg-btn .mdi { font-size: 14px; }
-
-/* ── Code editor ── */
-.code-editor-wrap {
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-  border: 1px solid var(--border);
-  margin-bottom: 4px;
-}
-
-.code-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 6px 8px 6px 14px;
-  background: #282c34;
-  gap: var(--space-sm);
-}
-
-.code-title {
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.5px;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-shrink: 0;
-}
-
-.code-title .mdi { font-size: 14px; color: #60a5fa; }
-
-.code-actions {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.run-label {
-  color: var(--text-secondary);
-  font-size: 12px;
-  white-space: nowrap;
-}
-
-.tab-picker {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-  background: #334155;
-  border-radius: var(--radius-md);
-  padding: 0 8px;
-  height: 30px;
-}
-
-.tab-picker .mdi { color: var(--text-muted); font-size: 14px; flex-shrink: 0; }
-
-.tab-picker-select {
-  background: transparent;
-  border: none;
-  color: #e2e8f0;
-  font-size: 12px;
-  outline: none;
-  cursor: pointer;
-  max-width: 200px;
-  padding: 0;
-}
-
-.tab-picker-select option { background: #1e293b; color: #e2e8f0; }
-
-.btn-run {
-  padding: 5px 14px;
-  font-size: 12px;
-  border-radius: var(--radius-md);
-  background: var(--success);
-  color: #fff;
-  border: none;
-  cursor: pointer;
-  font-weight: 600;
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-  transition: background 0.15s;
-  height: 30px;
-  white-space: nowrap;
-}
-
-.btn-run:hover { background: var(--success-hover); }
-.btn-run .mdi { font-size: 14px; }
-
-/* ── Import userscript ── */
-.import-userscript {
-  padding: 10px 0 0;
-}
-
-.import-userscript-row {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-}
-
-.import-icon {
-  color: var(--text-muted);
-  font-size: 16px;
-  flex-shrink: 0;
-}
-
-.import-userscript-input {
-  flex: 1;
-  background: var(--bg-input);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--text);
-  font-size: 12px;
-  padding: 7px 10px;
-  outline: none;
-}
-
-.import-userscript-input:focus { border-color: var(--blue); }
-.import-userscript-input::placeholder { color: var(--text-placeholder); }
-
-.btn-fetch {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-  padding: 7px 14px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border);
-  background: var(--bg-card);
-  color: var(--text-secondary);
-  font-size: 12px;
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-.btn-fetch:hover { background: var(--bg-hover); color: var(--text); }
-.btn-fetch:disabled { opacity: 0.5; cursor: not-allowed; }
-.btn-fetch .mdi { font-size: 14px; }
-
-.import-userscript-msg {
-  display: block;
-  font-size: 11px;
-  margin-top: 4px;
-  color: var(--text-muted);
-}
-
-
-/* ── Alerts ── */
-.alert {
-  padding: 14px 18px;
-  border-radius: var(--radius-xl);
-  font-size: 13px;
-  font-weight: 500;
-  margin-bottom: 20px;
-  line-height: 1.6;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  box-shadow: var(--shadow-sm);
-}
-
-.alert-warning { background: var(--warning-bg); border: none; border-left: 3px solid var(--warning-text); color: var(--warning-text); }
-.alert-info { background: var(--info-bg); border: none; border-left: 3px solid var(--info-text); color: var(--info-text); }
-.alert a { color: inherit; text-decoration: underline; cursor: pointer; }
-.alert a:hover { opacity: 0.8; }
-.alert-info .mdi, .alert-warning .mdi {
-  margin-right: 0;
-  font-size: 20px;
-  flex-shrink: 0;
-  margin-top: 1px;
-}
-
-/* ── Buttons ── */
-.action-bar {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: var(--space-3xl);
-  padding: 0;
-  border: none;
-  border-radius: 0;
-  background: transparent;
-  box-shadow: none;
-  position: sticky;
-  bottom: 24px;
-  z-index: 50;
-  pointer-events: none;
-}
-.action-bar .btn {
-  pointer-events: auto;
-  padding: 12px 28px;
-  font-size: 14px;
-  border-radius: var(--radius-full);
-  box-shadow: 0 4px 20px rgba(0,0,0,0.15), 0 1px 3px rgba(0,0,0,0.1);
-}
-
-.btn {
-  padding: 9px 18px;
-  border: none;
-  border-radius: var(--radius-md);
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  letter-spacing: 0.01em;
-}
-
-.btn-primary { background: var(--blue); color: #fff; box-shadow: 0 1px 3px var(--blue-bg); }
-.btn-primary:hover { background: var(--blue-hover); box-shadow: 0 4px 14px var(--blue-bg); transform: translateY(-1px); }
-.btn-primary:active { transform: translateY(0); box-shadow: 0 1px 2px var(--blue-bg); }
-
-.btn-secondary { background: var(--bg-card); color: var(--text-secondary); border: 1px solid var(--border); }
-.btn-secondary:hover { background: var(--bg-hover); border-color: var(--border); color: var(--text); }
-
-.btn-sm { padding: 5px 12px; font-size: 12px; border-radius: var(--radius-md); }
-
-/* ── Toast ── */
-.toast {
-  position: fixed;
-  bottom: 32px;
-  right: 32px;
-  z-index: 999;
-  padding: 16px 24px;
-  border-radius: var(--radius-full);
-  font-size: 15px;
-  font-weight: 600;
-  box-shadow: var(--shadow-xl), 0 0 0 1px rgba(255,255,255,0.1) inset;
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-  cursor: pointer;
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  letter-spacing: 0.01em;
-}
-
-.toast-success { background: var(--success); color: #fff; }
-.toast-error { background: var(--danger); color: #fff; }
-
-.toast-enter-active, .toast-leave-active { transition: all 0.5s cubic-bezier(0.16, 1, 0.3, 1); }
-.toast-enter-from, .toast-leave-to { opacity: 0; transform: translateY(32px) scale(0.9); }
-.toast-action {
-  margin-left: 12px;
-  padding: 6px 16px;
-  background: rgba(255,255,255,0.2);
-  color: inherit;
-  border: 1px solid rgba(255,255,255,0.3);
-  border-radius: var(--radius-full);
-  cursor: pointer;
-  font-weight: 700;
-  font-size: 13px;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.toast-action:hover { 
-  background: rgba(255,255,255,0.35); 
-  transform: scale(1.05);
-}
-
-/* ── Expand animation ── */
-.expand-enter-active, .expand-leave-active { transition: all 0.2s ease; }
-.expand-enter-from, .expand-leave-to { opacity: 0; }
-
-/* ── Export ── */
-.export-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 12px;
-}
-
-.export-header .tab-desc { margin-bottom: 0; }
-
-.export-actions { display: flex; gap: var(--space-sm); }
-
-.share-link-box {
-  margin-bottom: 12px;
-  padding: 12px 16px;
-  background: var(--info-bg);
-  border: 1px solid var(--info-border);
-  border-radius: var(--radius-lg);
-}
-
-.share-link-box .field-input {
-  font-size: 12px;
-  cursor: text;
-  margin-bottom: 6px;
-}
-
-.share-hint {
-  font-size: 12px;
-  color: var(--blue);
-  margin: 0;
-}
-
-.export-pre {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 16px;
-  font-family: 'SF Mono', Menlo, Consolas, monospace;
-  font-size: 12px;
-  overflow: auto;
-  max-height: 500px;
-  color: var(--text);
-}
-
-.tab-desc {
-  color: var(--text-secondary);
-  margin-bottom: 12px;
-}
-
-/* ── Section titles ── */
-.section-title {
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--text);
-  margin-bottom: 4px;
-}
-
-/* ── Import Tab ── */
-.import-tab-container {
-  display: flex;
-  flex-direction: column;
-  gap: 40px;
-}
-
-.import-section .section-header {
-  margin-bottom: 16px;
-}
-
-.import-divider {
-  height: 1px;
-  background: var(--border-light);
-  margin: 0;
-}
-
-/* ── Pack grid ── */
-.pack-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: var(--space-lg);
-}
-
-.pack-card {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
-  padding: 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  transition: all 0.25s cubic-bezier(0.16, 1, 0.3, 1);
-  position: relative;
-  overflow: hidden;
-}
-
-.pack-card::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: var(--pack-color, var(--blue));
-  opacity: 0;
-  transition: opacity 0.25s ease;
-}
-
-.pack-card:hover { 
-  box-shadow: var(--shadow-md); 
-  transform: translateY(-3px);
-  border-color: var(--border);
-}
-
-.pack-card:hover::before {
-  opacity: 1;
-}
-
-.pack-header {
-  display: flex;
-  align-items: center;
-  gap: var(--space-lg);
-  position: relative;
-  z-index: 1;
-}
-
-.pack-icon { 
-  font-size: 32px; 
-  line-height: 1;
-  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.1));
-  transition: transform 0.2s ease;
-}
-
-.pack-card:hover .pack-icon {
-  transform: scale(1.1) rotate(-5deg);
-}
-
-.pack-info { 
-  flex: 1; 
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.pack-name {
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--text);
-  letter-spacing: -0.01em;
-}
-
-.pack-meta {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.pack-desc {
-  font-size: 13px;
-  color: var(--text-secondary);
-  line-height: 1.5;
-  flex: 1;
-  position: relative;
-  z-index: 1;
-}
-
-.pack-actions {
-  display: flex;
-  gap: var(--space-sm);
-  margin-top: auto;
-  position: relative;
-  z-index: 1;
-}
-
-.pack-actions .btn {
-  flex: 1;
-  justify-content: center;
-}
-
-/* .btn-sm duplicate removed */
-
-/* ── JSON Import ── */
-.json-import-card {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
-  padding: 20px;
-  box-shadow: 0 2px 8px var(--shadow);
-}
-
-.json-textarea {
-  min-height: 160px;
-  font-size: 13px;
-  line-height: 1.5;
-}
-
-.json-action-bar {
-  margin-top: 16px;
-  padding-top: 16px;
-  border-top: 1px dashed var(--border-light);
-}
-
-.json-hint {
-  font-size: 13px;
-  color: var(--text-muted);
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.json-hint .mdi {
-  font-size: 16px;
-  color: var(--text-secondary);
-}
-
-/* ── Modal ── */
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 100;
-  background: rgba(0,0,0,0.3);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 24px;
-}
-
-.modal-panel {
-  background: var(--bg-card);
-  border-radius: 24px;
-  width: 100%;
-  max-width: 580px;
-  max-height: 85vh;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  box-shadow: var(--shadow-xl), 0 20px 40px rgba(0,0,0,0.2);
-  border: 1px solid var(--border-light);
-}
-
-.modal-header {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 24px 32px;
-  color: #fff;
-  position: relative;
-}
-
-.modal-icon { font-size: 36px; flex-shrink: 0; }
-
-.modal-title {
-  font-size: 18px;
-  font-weight: 700;
-  margin: 0;
-}
-
-.modal-subtitle {
-  font-size: 13px;
-  opacity: 0.85;
-  margin: 4px 0 0;
-}
-
-.modal-close {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-  background: rgba(255,255,255,0.2);
-  border: none;
-  color: #fff;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  font-size: 16px;
-  transition: background 0.15s;
-}
-
-.modal-close:hover { background: rgba(255,255,255,0.35); }
-
-.modal-body {
-  padding: 24px 32px;
-  overflow-y: auto;
-  flex: 1;
-}
-
-.modal-shortcuts {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.modal-shortcut-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 16px;
-  border-radius: var(--radius-lg);
-  gap: var(--space-md);
-  transition: background 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.modal-shortcut-row:nth-child(odd) { background: var(--bg-elevated); }
-.modal-shortcut-row:hover { background: var(--bg-hover); }
-
-.modal-shortcut-label {
-  font-size: 13px;
-  color: var(--text);
-}
-
-.modal-shortcut-keys {
-  display: flex;
-  gap: 3px;
-  flex-shrink: 0;
-}
-
-.modal-shortcut-keys kbd {
-  display: inline-block;
-  padding: 2px 7px;
-  background: var(--bg-hover);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  font-family: 'SF Mono', Menlo, monospace;
-  font-size: 11px;
-  color: var(--text-secondary);
-  text-transform: capitalize;
-}
-
-.modal-conflicts {
-  margin-top: 16px;
-  padding: 12px 16px;
-  background: var(--warning-bg);
-  border: 1px solid var(--warning-border);
-  border-radius: var(--radius-lg);
-}
-
-.modal-conflict-header {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--warning-text);
-  margin-bottom: 10px;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.modal-conflict-header .mdi { font-size: 16px; }
-
-.modal-conflict-options {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-}
-
-.radio-option {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  font-size: 13px;
-  color: var(--text-secondary);
-  cursor: pointer;
-}
-
-.radio-option input[type="radio"] {
-  accent-color: var(--blue);
-}
-
-.modal-footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--space-md);
-  padding: 20px 32px;
-  border-top: 1px solid var(--border);
-  background: var(--bg-elevated);
-}
-
-.modal-enter-active, .modal-leave-active { transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1); }
-.modal-enter-from, .modal-leave-to { opacity: 0; }
-.modal-enter-from .modal-panel, .modal-leave-to .modal-panel { transform: scale(0.9) translateY(16px); }
-
-/* ── Group site rules ── */
-.group-site-indicator {
-  font-size: 14px;
-  color: var(--blue);
-  opacity: 0.7;
-}
-
-.group-site-panel {
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--border-light);
-  background: var(--bg-elevated);
-}
-
-.group-site-fields {
-  display: flex;
-  gap: var(--space-md);
-}
-
-.group-site-field {
-  flex: 1;
-  min-width: 0;
-}
-
-.group-site-label {
-  display: block;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  margin-bottom: 4px;
-}
-
-.group-site-label .mdi {
-  font-size: 13px;
-  margin-right: 3px;
-}
-
-.group-site-textarea {
-  font-size: 12px !important;
-  padding: 6px 10px !important;
-  resize: vertical;
-}
-
-.group-site-hint {
-  font-size: 11px;
-  color: var(--text-muted);
-  margin: 8px 0 0;
-}
-
-.group-site-hint code {
-  background: var(--bg-hover);
-  padding: 1px 5px;
-  border-radius: 3px;
-  font-size: 11px;
-}
-
-/* ── Empty state ── */
-.empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 80px 24px;
-  text-align: center;
-  animation: emptyStateFadeIn 0.8s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-}
-
-@keyframes emptyStateFadeIn {
-  0% { opacity: 0; transform: translateY(20px); }
-  100% { opacity: 1; transform: translateY(0); }
-}
-
-.empty-state-icon {
-  font-size: 72px;
-  color: var(--blue);
-  margin-bottom: 24px;
-  opacity: 0.9;
-  filter: drop-shadow(0 8px 16px var(--blue-bg));
-  transform: scale(1);
-  transition: transform 0.5s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.empty-state:hover .empty-state-icon {
-  transform: scale(1.1) translateY(-4px);
-}
-
-.empty-state-title {
-  font-size: 24px;
-  font-weight: 700;
-  color: var(--text);
-  margin: 0 0 12px;
-  letter-spacing: -0.01em;
-}
-
-.empty-state-desc {
-  font-size: 15px;
-  color: var(--text-secondary);
-  max-width: 480px;
-  line-height: 1.6;
-  margin: 0 0 32px;
-}
-
-.empty-state-actions {
-  display: flex;
-  gap: var(--space-md);
-}
-
-.empty-state-actions .btn {
-  font-size: 15px;
-  padding: 12px 24px;
-  border-radius: var(--radius-xl);
-}
-
-/* ── Density toggle ── */
-.density-toggle {
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--bg-card);
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-size: 16px;
-  transition: all 0.15s;
-  flex-shrink: 0;
-  }
-.density-toggle:hover { background: var(--bg-hover); color: var(--text); }
-
-/* ── Condensed view ── */
-[data-density="condensed"] .shortcut-header {
-  padding: 2px 10px 0 6px;
-  gap: 2px;
-}
-
-[data-density="condensed"] .shortcut-label-title {
-  font-size: 11px;
-  padding: 1px 4px;
-}
-
-[data-density="condensed"] .shortcut-row {
-  padding: 4px 10px 6px;
-  gap: var(--space-sm);
-}
-
-[data-density="condensed"] .shortcut-card {
-  margin-bottom: 1px;
-  border-radius: var(--radius-sm);
-}
-
-[data-density="condensed"] .shortcut-list {
-  padding: 2px;
-  gap: 0;
-}
-
-[data-density="condensed"] .field-label {
-  display: none;
-}
-
-[data-density="condensed"] .field-label-row {
-  display: none;
-}
-
-[data-density="condensed"] .shortcut-col {
-  width: 240px;
-  flex: 0 0 240px;
-}
-
-[data-density="condensed"] .toggle.toggle-sm {
-  width: 26px;
-  height: 14px;
-  border-radius: 7px;
-}
-[data-density="condensed"] .toggle.toggle-sm .toggle-knob {
-  width: 10px;
-  height: 10px;
-}
-[data-density="condensed"] .toggle.toggle-sm.on .toggle-knob {
-  transform: translateX(12px);
-}
-
-[data-density="condensed"] .drag-handle {
-  font-size: 14px;
-  padding: 0;
-}
-
-[data-density="condensed"] .conflict-warnings {
-  padding: 0 10px 4px;
-}
-
-[data-density="condensed"] .group-header {
-  padding: 5px 10px;
-}
-
-[data-density="condensed"] .btn-add-to-group {
-  padding: 3px 6px;
-  font-size: 11px;
-}
-
-[data-density="condensed"] .shortcut-actions .btn-icon {
-  font-size: 14px;
-  padding: 9px;
-}
-</style>

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -11,9 +11,7 @@
     />
   </head>
   <body>
-    <div class="container">
-      <div id="app"></div>
-    </div>
+    <div id="app"></div>
     <script type="module" src="./main.ts"></script>
   </body>
 </html>

--- a/src/entrypoints/options/main.ts
+++ b/src/entrypoints/options/main.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+import './style.css'
 import App from './App.vue'
 
 createApp(App).mount('#app')

--- a/src/entrypoints/options/style.css
+++ b/src/entrypoints/options/style.css
@@ -1,0 +1,520 @@
+@import "tailwindcss";
+
+/* ── Tailwind Theme ── */
+@theme {
+  /* Font families */
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-mono: 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+
+  /* Custom colors mapped from CSS variables */
+  --color-surface: var(--bg);
+  --color-surface-card: var(--bg-card);
+  --color-surface-elevated: var(--bg-elevated);
+  --color-surface-input: var(--bg-input);
+  --color-surface-hover: var(--bg-hover);
+
+  --color-text-primary: var(--text);
+  --color-text-secondary: var(--text-secondary);
+  --color-text-muted: var(--text-muted);
+  --color-text-placeholder: var(--text-placeholder);
+
+  --color-border-default: var(--border);
+  --color-border-light: var(--border-light);
+
+  --color-accent: var(--blue);
+  --color-accent-hover: var(--blue-hover);
+  --color-accent-bg: var(--blue-bg);
+
+  --color-danger: var(--c-danger);
+  --color-danger-hover: var(--c-danger-hover);
+  --color-danger-bg: var(--c-danger-bg);
+  --color-danger-border: var(--c-danger-border);
+  --color-danger-text: var(--c-danger-text);
+
+  --color-success: var(--c-success);
+  --color-success-hover: var(--c-success-hover);
+  --color-success-bg: var(--c-success-bg);
+  --color-success-border: var(--c-success-border);
+  --color-success-text: var(--c-success-text);
+
+  --color-warning-bg: var(--c-warning-bg);
+  --color-warning-border: var(--c-warning-border);
+  --color-warning-text: var(--c-warning-text);
+
+  --color-info-bg: var(--c-info-bg);
+  --color-info-border: var(--c-info-border);
+  --color-info-text: var(--c-info-text);
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.04), 0 1px 3px rgba(0,0,0,0.06);
+  --shadow-md: 0 2px 4px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.06);
+  --shadow-lg: 0 4px 8px rgba(0,0,0,0.04), 0 12px 32px rgba(0,0,0,0.08);
+  --shadow-xl: 0 8px 16px rgba(0,0,0,0.06), 0 24px 56px rgba(0,0,0,0.12);
+
+  /* Animations */
+  --animate-fade-in: fadeIn 0.15s ease;
+  --animate-empty-state: emptyStateFadeIn 0.8s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+  @keyframes emptyStateFadeIn {
+    0% { opacity: 0; transform: translateY(20px); }
+    100% { opacity: 1; transform: translateY(0); }
+  }
+  @keyframes pulse-recording {
+    0% { transform: scale(1); box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.4); }
+    50% { transform: scale(0.95); box-shadow: 0 0 0 6px rgba(239, 68, 68, 0); }
+    100% { transform: scale(1); box-shadow: 0 0 0 0 rgba(239, 68, 68, 0); }
+  }
+  @keyframes slideUp {
+    from { opacity: 0; transform: translateY(12px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  @keyframes popIn {
+    0% { opacity: 0; transform: scale(0.8); }
+    50% { transform: scale(1.1); }
+    100% { opacity: 1; transform: scale(1); }
+  }
+}
+
+/* ── Reset ── */
+*, *::before, *::after { box-sizing: border-box; }
+
+/* ── Light Theme (default) ── */
+:root {
+  --bg: #f8f9fb;
+  --bg-card: #ffffff;
+  --bg-elevated: #f3f4f8;
+  --bg-input: #ffffff;
+  --bg-hover: #eef0f5;
+
+  --text: #111827;
+  --text-secondary: #4b5563;
+  --text-muted: #9ca3af;
+  --text-placeholder: #d1d5db;
+
+  --border: #e5e7eb;
+  --border-light: #f0f1f4;
+
+  --blue: #4f46e5;
+  --blue-hover: #4338ca;
+  --blue-bg: rgba(79,70,229,0.1);
+
+  --c-danger: #ef4444;
+  --c-danger-hover: #dc2626;
+  --c-danger-bg: #fef2f2;
+  --c-danger-border: #fecaca;
+  --c-danger-text: #991b1b;
+  --c-success: #059669;
+  --c-success-hover: #047857;
+  --c-success-bg: #ecfdf5;
+  --c-success-border: #a7f3d0;
+  --c-success-text: #065f46;
+  --c-warning-bg: #fffbeb;
+  --c-warning-border: #fde68a;
+  --c-warning-text: #92400e;
+  --c-info-bg: #eef2ff;
+  --c-info-border: #c7d2fe;
+  --c-info-text: #3730a3;
+
+  --focus-ring: 0 0 0 3px rgba(79,70,229,0.15);
+}
+
+/* ── Dark Theme ── */
+[data-theme="dark"] {
+  --bg: #0c0f1a;
+  --bg-card: #161b2e;
+  --bg-elevated: #1c2237;
+  --bg-input: #0c0f1a;
+  --bg-hover: #242b42;
+
+  --text: #e8eaf0;
+  --text-secondary: #8b92a8;
+  --text-muted: #565e78;
+  --text-placeholder: #3d4560;
+
+  --border: #2a3150;
+  --border-light: #1e2440;
+
+  --blue: #6366f1;
+  --blue-hover: #818cf8;
+  --blue-bg: rgba(99,102,241,0.15);
+
+  --c-danger: #f87171;
+  --c-danger-hover: #ef4444;
+  --c-danger-bg: rgba(239,68,68,0.12);
+  --c-danger-border: rgba(239,68,68,0.25);
+  --c-danger-text: #fca5a5;
+  --c-success: #34d399;
+  --c-success-hover: #10b981;
+  --c-success-bg: rgba(52,211,153,0.12);
+  --c-success-border: rgba(52,211,153,0.25);
+  --c-success-text: #6ee7b7;
+  --c-warning-bg: rgba(245,158,11,0.08);
+  --c-warning-border: rgba(245,158,11,0.15);
+  --c-warning-text: #f59e0b;
+  --c-info-bg: rgba(99,102,241,0.12);
+  --c-info-border: rgba(99,102,241,0.25);
+  --c-info-text: #a5b4fc;
+
+  --focus-ring: 0 0 0 3px rgba(99,102,241,0.25);
+}
+
+/* ── Base styles ── */
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  background-image: radial-gradient(circle at 50% 0%, var(--bg-card) 0%, transparent 60%);
+  background-attachment: fixed;
+  color: var(--text);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  font-size: 15px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a { color: var(--blue); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ── Shared component classes ── */
+/* These are used across many components and need global definitions */
+
+.field-input, .field-select {
+  width: 100%;
+  padding: 9px 12px;
+  border: 1.5px solid var(--border);
+  border-radius: 8px;
+  font-size: 14px;
+  color: var(--text);
+  background: var(--bg-input);
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.field-input:focus, .field-select:focus {
+  outline: none;
+  border-color: var(--blue);
+  box-shadow: var(--focus-ring);
+}
+.field-input::placeholder { color: var(--text-placeholder); }
+
+.field-textarea {
+  width: 100%;
+  padding: 9px 12px;
+  border: 1.5px solid var(--border);
+  border-radius: 8px;
+  font-size: 14px;
+  color: var(--text);
+  background: var(--bg-input);
+  transition: border-color 0.15s, box-shadow 0.15s;
+  resize: vertical;
+}
+.field-textarea:focus {
+  outline: none;
+  border-color: var(--blue);
+  box-shadow: var(--focus-ring);
+}
+
+.shortcut-input { font-family: 'SF Mono', Menlo, Consolas, monospace; font-weight: 500; }
+.mono { font-family: 'SF Mono', Menlo, Consolas, monospace; font-size: 14px; }
+
+.btn {
+  padding: 9px 18px;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  letter-spacing: 0.01em;
+}
+.btn-primary {
+  background: var(--blue);
+  color: #fff;
+  box-shadow: 0 1px 3px var(--blue-bg);
+}
+.btn-primary:hover {
+  background: var(--blue-hover);
+  box-shadow: 0 4px 14px var(--blue-bg);
+  transform: translateY(-1px);
+}
+.btn-primary:active { transform: translateY(0); }
+
+.btn-secondary {
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+.btn-secondary:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.btn-sm { padding: 5px 12px; font-size: 12px; }
+
+.btn-icon {
+  padding: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all 0.15s;
+  font-size: 16px;
+  flex-shrink: 0;
+}
+.btn-icon:hover { background: var(--bg-hover); color: var(--text-secondary); border-color: var(--border); }
+
+.section-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.tab-desc {
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+
+.alert {
+  padding: 14px 18px;
+  border-radius: 14px;
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 20px;
+  line-height: 1.6;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 1px 3px rgba(0,0,0,0.06);
+}
+.alert-warning { background: var(--c-warning-bg); border: none; border-left: 3px solid var(--c-warning-text); color: var(--c-warning-text); }
+.alert-info { background: var(--c-info-bg); border: none; border-left: 3px solid var(--c-info-text); color: var(--c-info-text); }
+.alert .mdi { font-size: 20px; flex-shrink: 0; }
+
+/* Pack card shared styles */
+.pack-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
+}
+.pack-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  transition: all 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+  position: relative;
+  overflow: hidden;
+}
+.pack-card:hover {
+  box-shadow: 0 2px 4px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.06);
+  transform: translateY(-3px);
+}
+.pack-header { display: flex; align-items: center; gap: 16px; }
+.pack-icon { font-size: 32px; line-height: 1; }
+.pack-info { flex: 1; display: flex; flex-direction: column; gap: 2px; }
+.pack-name { font-size: 16px; font-weight: 700; color: var(--text); }
+.pack-meta { font-size: 12px; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.pack-desc { font-size: 13px; color: var(--text-secondary); line-height: 1.5; flex: 1; }
+.pack-actions { display: flex; gap: 8px; margin-top: auto; }
+.pack-actions .btn { flex: 1; justify-content: center; }
+
+/* Modal shared styles */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0,0,0,0.3);
+  backdrop-filter: blur(16px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+.modal-panel {
+  background: var(--bg-card);
+  border-radius: 24px;
+  width: 100%;
+  max-width: 580px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 8px 16px rgba(0,0,0,0.06), 0 24px 56px rgba(0,0,0,0.12), 0 20px 40px rgba(0,0,0,0.2);
+  border: 1px solid var(--border-light);
+}
+.modal-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 24px 32px;
+  color: #fff;
+  position: relative;
+}
+.modal-icon { font-size: 36px; flex-shrink: 0; }
+.modal-title { font-size: 18px; font-weight: 700; margin: 0; }
+.modal-subtitle { font-size: 13px; opacity: 0.85; margin: 4px 0 0; }
+.modal-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: rgba(255,255,255,0.2);
+  border: none;
+  color: #fff;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 16px;
+  transition: background 0.15s;
+}
+.modal-close:hover { background: rgba(255,255,255,0.35); }
+.modal-body { padding: 24px 32px; overflow-y: auto; flex: 1; }
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 20px 32px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-elevated);
+}
+.modal-shortcuts { display: flex; flex-direction: column; gap: 2px; }
+.modal-shortcut-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-radius: 10px;
+  gap: 12px;
+  transition: background 0.2s;
+}
+.modal-shortcut-row:nth-child(odd) { background: var(--bg-elevated); }
+.modal-shortcut-row:hover { background: var(--bg-hover); }
+.modal-shortcut-label { font-size: 13px; color: var(--text); }
+.modal-shortcut-keys { display: flex; gap: 3px; flex-shrink: 0; }
+.modal-shortcut-keys kbd {
+  display: inline-block;
+  padding: 2px 7px;
+  background: var(--bg-hover);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  font-family: 'SF Mono', Menlo, monospace;
+  font-size: 11px;
+  color: var(--text-secondary);
+  text-transform: capitalize;
+}
+
+/* Segmented control */
+.segmented {
+  display: flex;
+  background: var(--bg-hover);
+  border-radius: 10px;
+  padding: 3px;
+  gap: 2px;
+  border: 1px solid var(--border-light);
+}
+.seg-btn {
+  flex: 1;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+.seg-btn:hover { color: var(--text); }
+.seg-btn.active { background: var(--bg-card); color: var(--blue); box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 1px 3px rgba(0,0,0,0.06); font-weight: 600; }
+
+/* ── Vue transition: toast ── */
+.toast-enter-active, .toast-leave-active { transition: all 0.5s cubic-bezier(0.16, 1, 0.3, 1); }
+.toast-enter-from, .toast-leave-to { opacity: 0; transform: translateY(32px) scale(0.9); }
+
+/* ── Vue transition: expand ── */
+.expand-enter-active, .expand-leave-active { transition: all 0.2s ease; }
+.expand-enter-from, .expand-leave-to { opacity: 0; }
+
+/* ── Vue transition: modal ── */
+.modal-enter-active, .modal-leave-active { transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1); }
+.modal-enter-from, .modal-leave-to { opacity: 0; }
+.modal-enter-from .modal-panel, .modal-leave-to .modal-panel { transform: scale(0.9) translateY(16px); }
+
+/* ── Vue transition: fade (onboarding) ── */
+.fade-enter-active, .fade-leave-active { transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1); }
+.fade-enter-from, .fade-leave-to { opacity: 0; transform: translateY(8px); }
+
+/* ── Toggle switch (complex component, kept as utility) ── */
+.toggle {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  border-radius: 9999px;
+  border: none;
+  background: var(--border);
+  cursor: pointer;
+  transition: background 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+  flex-shrink: 0;
+  padding: 0;
+}
+.toggle.on { background: var(--blue); }
+.toggle-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.15), 0 1px 1px rgba(0,0,0,0.06);
+  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.toggle.on .toggle-knob { transform: translateX(20px); }
+.toggle.toggle-sm { width: 36px; height: 20px; }
+.toggle.toggle-sm .toggle-knob { width: 16px; height: 16px; top: 2px; left: 2px; }
+.toggle.toggle-sm.on .toggle-knob { transform: translateX(16px); }
+
+/* ── Condensed density overrides ── */
+[data-density="condensed"] .shortcut-header { padding: 2px 10px 0 6px; gap: 2px; }
+[data-density="condensed"] .shortcut-label-title { font-size: 11px; padding: 1px 4px; }
+[data-density="condensed"] .shortcut-row { padding: 4px 10px 6px; gap: 8px; }
+[data-density="condensed"] .shortcut-card { margin-bottom: 1px; border-radius: 5px; }
+[data-density="condensed"] .shortcut-list { padding: 2px; gap: 0; }
+[data-density="condensed"] .field-label { display: none; }
+[data-density="condensed"] .field-label-row { display: none; }
+[data-density="condensed"] .shortcut-col { width: 240px; flex: 0 0 240px; }
+[data-density="condensed"] .toggle.toggle-sm { width: 26px; height: 14px; border-radius: 7px; }
+[data-density="condensed"] .toggle.toggle-sm .toggle-knob { width: 10px; height: 10px; }
+[data-density="condensed"] .toggle.toggle-sm.on .toggle-knob { transform: translateX(12px); }
+[data-density="condensed"] .drag-handle { font-size: 14px; padding: 0; }
+[data-density="condensed"] .conflict-warnings { padding: 0 10px 4px; }
+[data-density="condensed"] .group-header { padding: 5px 10px; }
+[data-density="condensed"] .btn-add-to-group { padding: 3px 6px; font-size: 11px; }
+[data-density="condensed"] .shortcut-actions .btn-icon { font-size: 14px; padding: 9px; }
+
+/* ── Dark mode header override ── */
+[data-theme="dark"] .app-header {
+  background: rgba(12,15,26,0.88);
+}


### PR DESCRIPTION
## Summary
Migrates the entire Shortkeys options page from custom CSS (~3,750 lines removed) to Tailwind CSS v4 utility classes (~1,600 lines added).

### Changes
- **Infrastructure**: Installed `tailwindcss` v4 + `@tailwindcss/postcss`, created `postcss.config.mjs` and `style.css` with theme configuration
- **App.vue**: 2,324 → 482 lines (removed ~1,842 lines of CSS)
- **12 components migrated**: All `<style>` blocks removed (except CodeEditor's `:deep()` selectors)
- **Shared classes**: Global utility classes (`btn`, `field-input`, `modal-*`, `pack-*`, etc.) defined in `style.css`
- **Dark mode**: CSS custom properties preserved for light/dark theming
- **Density overrides**: Kept in `style.css` for condensed view support

### Testing
- 730/730 tests passing ✅
- Production build clean (1.11 MB) ✅