### PR TITLE
Remove dead tab group expand actions

### DIFF
--- a/src/actions/action-handlers.ts
+++ b/src/actions/action-handlers.ts
@@ -63,6 +63,38 @@ function copyToClipboard(text: string): void {
   )
 }
 
+function isSavedTabGroupError(error: unknown): boolean {
+  return error instanceof Error && /saved groups are not editable/i.test(error.message)
+}
+
+async function getCurrentTabGroupId(): Promise<number | null> {
+  const [tab] = await browser.tabs.query({ currentWindow: true, active: true })
+  const groupId = (tab as any).groupId ?? -1
+  return groupId === -1 ? null : groupId
+}
+
+async function updateTabGroupCollapsed(groupId: number, collapsed: boolean): Promise<'success' | 'saved' | 'failed'> {
+  try {
+    const updatedGroup = await chrome.tabGroups!.update(groupId, { collapsed })
+    if (updatedGroup?.collapsed === collapsed) return 'success'
+    if (chrome.tabGroups?.get) {
+      const group = await chrome.tabGroups.get(groupId)
+      if (group.collapsed === collapsed) return 'success'
+    }
+  } catch (error) {
+    if (isSavedTabGroupError(error)) return 'saved'
+  }
+  return 'failed'
+}
+
+function showTabGroupCollapseError(result: 'saved' | 'failed', collapsed: boolean): void {
+  if (result === 'saved') {
+    showPageToast('Chrome cannot change saved tab groups')
+    return
+  }
+  showPageToast(collapsed ? 'Chrome could not collapse this tab group' : 'Chrome could not expand this tab group')
+}
+
 /**
  * Map of action name → handler function.
  * Each handler receives the full request object and returns true if handled.
@@ -267,6 +299,22 @@ const actionHandlers: Record<string, ActionHandler> = {
     if (request.groupname) {
       await chrome.tabGroups.update(groupId, { title: request.groupname })
       showPageToast(`✓ Group named "${request.groupname}"`)
+    }
+    return true
+  },
+
+  collapsegroup: async () => {
+    if (!chrome.tabGroups?.update) return true
+    const groupId = await getCurrentTabGroupId()
+    if (groupId === null) {
+      showPageToast('Tab is not in a group')
+      return true
+    }
+    const result = await updateTabGroupCollapsed(groupId, true)
+    if (result === 'success') {
+      showPageToast('✓ Group collapsed')
+    } else {
+      showTabGroupCollapseError(result, true)
     }
     return true
   },

--- a/src/utils/actions-registry.ts
+++ b/src/utils/actions-registry.ts
@@ -86,6 +86,7 @@ export const ACTION_CATEGORIES: Record<string, ActionDefinition[]> = {
     { value: 'ungrouptab', label: 'Ungroup tab', description: 'Remove selected tabs (or current tab) from their tab group' },
     { value: 'togglegrouptab', label: 'Toggle group/ungroup', description: 'Group ungrouped tabs or ungroup grouped tabs (operates on selection)' },
     { value: 'namegroup', label: 'Name tab group', description: 'Set the title of the current tab\'s group' },
+    { value: 'collapsegroup', label: 'Collapse tab group', description: 'Collapse the selected tab\'s group to hide its tabs' },
     { value: 'selecttableft', label: 'Select tab to the left', description: 'Extend tab selection to include the tab on the left' },
     { value: 'selecttabright', label: 'Select tab to the right', description: 'Extend tab selection to include the tab on the right' },
   ],

--- a/tests/action-handlers.test.ts
+++ b/tests/action-handlers.test.ts
@@ -522,6 +522,34 @@ describe('handleAction', () => {
       expect(mockShowPageToast).toHaveBeenCalledWith('Tab is not in a group')
     })
 
+    it('collapsegroup collapses current tab group', async () => {
+      mockTabsQuery.mockResolvedValue([{ id: 1, index: 0, groupId: 3 }])
+      await handleAction('collapsegroup')
+      expect(chrome.tabGroups.update).toHaveBeenCalledWith(3, { collapsed: true })
+    })
+
+    it('collapsegroup shows a saved-group error when Chrome rejects the update', async () => {
+      mockTabsQuery.mockResolvedValue([{ id: 1, index: 0, groupId: 3 }])
+      vi.mocked(chrome.tabGroups.update).mockRejectedValueOnce(new Error('Saved groups are not editable'))
+      await handleAction('collapsegroup')
+      expect(mockShowPageToast).toHaveBeenCalledWith('Chrome cannot change saved tab groups')
+    })
+
+    it('collapsegroup shows a failure toast when the group state does not change', async () => {
+      mockTabsQuery.mockResolvedValue([{ id: 1, index: 0, groupId: 3 }])
+      vi.mocked(chrome.tabGroups.update).mockResolvedValueOnce({ collapsed: false } as any)
+      vi.mocked(chrome.tabGroups.get).mockResolvedValueOnce({ collapsed: false } as any)
+      await handleAction('collapsegroup')
+      expect(mockShowPageToast).toHaveBeenCalledWith('Chrome could not collapse this tab group')
+    })
+
+    it('collapsegroup shows toast when tab is not in a group', async () => {
+      mockTabsQuery.mockResolvedValue([{ id: 1, index: 0, groupId: -1 }])
+      await handleAction('collapsegroup')
+      expect(chrome.tabGroups.update).not.toHaveBeenCalled()
+      expect(mockShowPageToast).toHaveBeenCalledWith('Tab is not in a group')
+    })
+
     it('selecttableft extends selection one tab to the left', async () => {
       mockTabsQuery
         .mockResolvedValueOnce([{ id: 1, index: 0 }, { id: 2, index: 1 }, { id: 3, index: 2 }]) // all tabs

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -122,6 +122,7 @@ export default defineConfig({
       '85-ungrouptab': { description: 'TABS: Remove tab from group' },
       '86-togglegrouptab': { description: 'TABS: Toggle group/ungroup tab' },
       '87-namegroup': { description: 'TABS: Name current tab group' },
+      '88-collapsegroup': { description: 'TABS: Collapse selected tab group' },
       '91-selecttableft': { description: 'TABS: Select tab to the left' },
       '92-selecttabright': { description: 'TABS: Select tab to the right' },
     },


### PR DESCRIPTION
## Summary
- restore `collapsegroup`
- keep `expandgroup` and `togglecollapsegroup` removed
- retain the explicit saved-group/failure handling around tab-group collapse

## Why
Chrome 146 stable appears to have fixed the tab-group repaint issue that previously made `collapsegroup` unreliable.

We re-tested this on Chrome `146.0.7680.76`, and `collapsegroup` now visibly collapses the active tab's group as expected.

## Validation
- `npm test`
- `npm run build`
- `npm run visual-review`
- manual verification in Chrome `146.0.7680.76`
