### PR TITLE
Fix Firefox AMO manifest warnings

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'wxt'
 export default defineConfig({
   modules: ['@wxt-dev/module-vue'],
   srcDir: 'src',
-  manifest: {
+  manifest: ({ browser }) => ({
     name: 'Shortkeys (Custom Keyboard Shortcuts)',
     short_name: 'Shortkeys',
     description: 'Custom keyboard shortcuts for your browser',
@@ -12,6 +12,10 @@ export default defineConfig({
       gecko: {
         id: 'Shortkeys@Shortkeys.com',
         strict_min_version: '109.0',
+        data_collection_permissions: {
+          private_browsing_allow: false,
+          data_collection: false,
+        },
       },
     },
     icons: {
@@ -135,13 +139,16 @@ export default defineConfig({
       'bookmarks',
       'sessions',
       'management',
-      'debugger',
+      ...(browser !== 'firefox' ? ['debugger'] : []),
       'scripting',
       'notifications',
       'activeTab',
-      'userScripts',
+      ...(browser !== 'firefox' ? ['userScripts'] : []),
     ],
-    optional_permissions: ['clipboardRead', 'tabGroups'],
+    optional_permissions: [
+      'clipboardRead',
+      ...(browser !== 'firefox' ? ['tabGroups'] : []),
+    ],
     host_permissions: ['*://*/*'],
     externally_connectable: {
       matches: ['https://shortkeys.app/*', 'http://localhost/*'],
@@ -149,5 +156,5 @@ export default defineConfig({
     content_security_policy: {
       extension_pages: "script-src 'self'; object-src 'self'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline' https://cdn.materialdesignicons.com https://cdn.jsdelivr.net;",
     },
-  },
+  }),
 })


### PR DESCRIPTION
Resolves the three AMO validation warnings from the v5.0.0 Firefox upload:

1. **`debugger` invalid permission** — excluded from Firefox build (API doesn't exist in Firefox, code already guards)
2. **`userScripts` invalid permission** — excluded from Firefox build (same reason)
3. **`data_collection_permissions` missing** — added to `browser_specific_settings.gecko` (will be required by AMO for all extensions)

Also excludes `tabGroups` from Firefox `optional_permissions` since Firefox doesn't have that permission.

Converts the WXT manifest config from a static object to a function so permissions can be conditionally included based on the target browser.