### PR TITLE
Fix: stop shortcut recording on click outside (#807)

### DIFF
--- a/src/components/ShortcutRecorder.vue
+++ b/src/components/ShortcutRecorder.vue
@@ -18,17 +18,24 @@ function startRecording() {
   recordedKeys.value = []
   emit('update:modelValue', '')
   window.addEventListener('keydown', captureKey, true)
+  window.addEventListener('mousedown', onClickOutside, true)
   resetAutoStop()
 }
 
 function stopRecording() {
   recording.value = false
   window.removeEventListener('keydown', captureKey, true)
+  window.removeEventListener('mousedown', onClickOutside, true)
   if (autoStopTimer) { clearTimeout(autoStopTimer); autoStopTimer = null }
   // Emit the final accumulated sequence (e.g. "j j" for Mousetrap sequence)
   if (recordedKeys.value.length > 0) {
     emit('update:modelValue', recordedKeys.value.join(' '))
   }
+}
+
+function onClickOutside(e: MouseEvent) {
+  const el = (e.target as HTMLElement).closest('.recorder-wrap')
+  if (!el) stopRecording()
 }
 
 function resetAutoStop() {


### PR DESCRIPTION
Fixes #807

The shortcut recorder kept recording after clicking elsewhere (e.g. the action dropdown or another shortcut's recorder), allowing two recorders to be active simultaneously.

**Fix:** Add a `mousedown` listener during recording that stops capture when clicking anywhere outside the recorder component. Clicking the Stop button or the recorder's own input still works as before.

One-line change in `ShortcutRecorder.vue` — adds/removes the listener alongside the existing `keydown` listener.