### PR TITLE
Add OnePageCRM community pack (#811)

### DIFF
--- a/packs/community/onepagecrm.json
+++ b/packs/community/onepagecrm.json
@@ -1,0 +1,18 @@
+{
+  "name": "OnePageCRM",
+  "icon": "📙",
+  "description": "Speed up your OnePageCRM workflow with shortcuts for navigating contacts, managing actions, and searching.",
+  "author": "dannypernik",
+  "shortcuts": [
+    { "key": "meta+shift+k", "action": "javascript", "label": "Previous contact", "code": "document.querySelector('.prev-contact span').click();" },
+    { "key": "meta+shift+l", "action": "javascript", "label": "Next contact", "code": "document.querySelector('.next-contact span').click();" },
+    { "key": "meta+enter", "action": "javascript", "label": "Mark action done", "code": "document.querySelector('.done-marker').click();" },
+    { "key": "meta+shift+enter", "action": "javascript", "label": "Edit action", "code": "document.querySelector('.name.strong').click();\nsetTimeout(()=>{document.getSelection().modify('move', 'forward', 'lineboundary')},10);" },
+    { "key": "meta+'", "action": "javascript", "label": "Edit action date", "code": "document.querySelector('.next-action-form .current_date .action_date').click();" },
+    { "key": "meta+shift+x", "action": "javascript", "label": "Close sales cycle", "code": "document.querySelector('.close-sales-link').click();\ndocument.querySelector('.submit_button').click();" },
+    { "key": "meta+shift+o", "action": "javascript", "label": "View first contact", "code": "document.querySelector('.list-inside > div:first-of-type').click();\nlocation.reload();" },
+    { "key": "meta+shift+c", "action": "javascript", "label": "Show calendar", "code": "document.querySelectorAll('.user-actions .next-action .action-flag-container')[0].click();" },
+    { "key": "meta+alt+c", "action": "javascript", "label": "Close contact", "code": "document.querySelector('.close-sales-link').click();" },
+    { "key": "meta+shift+s", "action": "javascript", "label": "Search contacts", "code": "document.querySelector('#search').focus();\ndocument.querySelector('#search').select();" }
+  ]
+}


### PR DESCRIPTION
Adds a community shortcut pack for [OnePageCRM](https://www.onepagecrm.com/) submitted by @dannypernik in #811.

**10 shortcuts** for navigating contacts, managing actions, searching, and more.

**Cleanup from submission:**
- Converted `command`→`meta` and `option`→`alt` (Mousetrap format)
- Removed one shortcut that used `openbookmark` with a `code` field (conflicting action/code)
- Labels use sentence case without the "CRM" prefix (the pack name already identifies the app)

Closes #811