### PR TITLE
Fix incorrect Mac DevTools conflict warning (#810)

### DIFF
--- a/src/utils/shortcut-conflicts.ts
+++ b/src/utils/shortcut-conflicts.ts
@@ -107,7 +107,6 @@ const MAC_DEFAULTS: Record<string, string> = {
   'meta+-': 'Zoom out',
   'meta+0': 'Reset zoom',
   'meta+alt+i': 'Open developer tools',
-  'meta+shift+i': 'Open developer tools',
   'meta+alt+j': 'Open console',
   'meta+shift+c': 'Inspect element',
   'meta+a': 'Select all',


### PR DESCRIPTION
On macOS, Chrome DevTools opens with `Cmd+Option+I` (`meta+alt+i`), not `Cmd+Shift+I` (`meta+shift+i`). The latter is the Windows/Linux shortcut (`ctrl+shift+i`).

Removes the incorrect `meta+shift+i` entry from the Mac defaults so users don't see a false conflict warning when using that combo on Mac.

Closes #810