### PR TITLE
Fix: bookmark dropdown empty after v5 upgrade (#816)

### DIFF
--- a/src/composables/useJsTools.ts
+++ b/src/composables/useJsTools.ts
@@ -5,16 +5,16 @@ import { resolveUserscriptUrl, parseUserscript } from '@/utils/fetch-userscript'
 import { useShortcuts } from './useShortcuts'
 import { useToast } from './useToast'
 
+const openTabs = ref<{ id: number; title: string; url: string; favIconUrl?: string }[]>([])
+const selectedTabId = ref<number | null>(null)
+const bookmarks = ref<{ title: string; url: string }[]>([])
+const userscriptUrl = ref('')
+const userscriptLoading = ref(false)
+const userscriptMessage = ref('')
+
 export function useJsTools() {
   const { keys } = useShortcuts()
   const { showSnack } = useToast()
-
-  const openTabs = ref<{ id: number; title: string; url: string; favIconUrl?: string }[]>([])
-  const selectedTabId = ref<number | null>(null)
-  const bookmarks = ref<{ title: string; url: string }[]>([])
-  const userscriptUrl = ref('')
-  const userscriptLoading = ref(false)
-  const userscriptMessage = ref('')
 
   async function refreshTabs() {
     const tabs = await chrome.tabs.query({})


### PR DESCRIPTION
The bookmark dropdown in shortcut settings showed "No matching actions" because `useJsTools()` created a new `bookmarks` ref on every call. `App.vue` loaded bookmarks into its copy, but `ShortcutDetails.vue` had a separate empty copy.

**Fix:** Move shared reactive state (`bookmarks`, `openTabs`, `selectedTabId`, etc.) to module scope so all consumers share the same data — matching the existing pattern used by `useShortcuts`, `useToast`, and other composables.

Closes #816