### PR TITLE
fix: AMO data_collection_permissions missing required field

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -13,8 +13,7 @@ export default defineConfig({
         id: 'Shortkeys@Shortkeys.com',
         strict_min_version: '109.0',
         data_collection_permissions: {
-          private_browsing_allow: false,
-          data_collection: false,
+          required: false,
         },
       },
     },


### PR DESCRIPTION
AMO rejects the Firefox upload because `data_collection_permissions` needs the `required` property. Set to `false` since Shortkeys doesn't collect any data.