### PR TITLE
fix: remove data_collection_permissions until AMO supports no-data extensions

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -12,9 +12,6 @@ export default defineConfig({
       gecko: {
         id: 'Shortkeys@Shortkeys.com',
         strict_min_version: '109.0',
-        data_collection_permissions: {
-          required: false,
-        },
       },
     },
     icons: {


### PR DESCRIPTION
AMO requires `required` to be an array with ≥1 item, so extensions that collect no data can't use this field yet. Removing it — it was only a warning, not a blocker for existing extensions.