### PR TITLE
feat: support group-level site rules in shortcut packs

### DIFF
--- a/src/composables/useGroups.ts
+++ b/src/composables/useGroups.ts
@@ -9,16 +9,16 @@ import { saveGroupSettings, loadGroupSettings } from '@/utils/storage'
 
 export const DEFAULT_GROUP = 'My Shortcuts'
 
+const collapsedGroups = ref<Set<string>>(new Set())
+const editingGroupName = ref<string | null>(null)
+const newGroupName = ref('')
+const groupMenuOpen = ref<string | null>(null)
+const groupSettings = reactive<Record<string, GroupSettings>>({})
+const expandedGroupSiteFilter = ref<string | null>(null)
+
 export function useGroups() {
   const { keys } = useShortcuts()
   const { filteredIndices } = useSearch()
-
-  const collapsedGroups = ref<Set<string>>(new Set())
-  const editingGroupName = ref<string | null>(null)
-  const newGroupName = ref('')
-  const groupMenuOpen = ref<string | null>(null)
-  const groupSettings = reactive<Record<string, GroupSettings>>({})
-  const expandedGroupSiteFilter = ref<string | null>(null)
 
   /** Get ordered list of unique group names */
   const groupNames = computed(() => {

--- a/src/composables/usePacks.ts
+++ b/src/composables/usePacks.ts
@@ -2,6 +2,7 @@ import { ref, computed } from 'vue'
 import { v4 as uuid } from 'uuid'
 import type { ShortcutPack } from '@/packs'
 import { useShortcuts } from './useShortcuts'
+import { useGroups } from './useGroups'
 import { useToast } from './useToast'
 import { normalizeKey, couldSiteFiltersOverlap } from '@/utils/shortcut-conflicts'
 import type { KeySetting } from '@/utils/url-matching'
@@ -100,6 +101,13 @@ export function usePacks() {
     } else {
       // Keep both
       keys.value.push(...newShortcuts)
+    }
+
+    // Apply group-level site rules if the pack includes them
+    if (pack.groupSettings) {
+      const { groupSettings, persistGroupSettings } = useGroups()
+      groupSettings[groupName] = { ...pack.groupSettings }
+      await persistGroupSettings()
     }
 
     const droppedCount = pack.shortcuts.length - nonExactShortcuts.length

--- a/src/packs/index.ts
+++ b/src/packs/index.ts
@@ -1,4 +1,4 @@
-import type { KeySetting } from '@/utils/url-matching'
+import type { KeySetting, GroupSettings } from '@/utils/url-matching'
 
 export interface ShortcutPack {
   id: string
@@ -7,6 +7,7 @@ export interface ShortcutPack {
   description: string
   color: string
   shortcuts: KeySetting[]
+  groupSettings?: GroupSettings
 }
 
 import vimPack from '../../packs/official/vim.json'

--- a/tests/pack-group-site-rules.test.ts
+++ b/tests/pack-group-site-rules.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+
+const mockSyncGet = vi.fn()
+const mockSyncSet = vi.fn()
+const mockSyncRemove = vi.fn()
+const mockLocalGet = vi.fn()
+const mockLocalSet = vi.fn()
+const mockOnChanged = vi.fn()
+
+const originalChrome = globalThis.chrome
+const originalBlob = globalThis.Blob
+
+// @ts-ignore
+globalThis.chrome = {
+  ...(originalChrome ?? {}),
+  storage: {
+    sync: { get: mockSyncGet, set: mockSyncSet, remove: mockSyncRemove },
+    local: { get: mockLocalGet, set: mockLocalSet },
+    onChanged: { addListener: mockOnChanged },
+  },
+}
+
+// @ts-ignore
+globalThis.Blob = class Blob {
+  constructor(public parts: any[]) {}
+  get size() { return this.parts.join('').length }
+}
+
+afterAll(() => {
+  globalThis.chrome = originalChrome
+  globalThis.Blob = originalBlob
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockSyncGet.mockResolvedValue({})
+  mockSyncSet.mockResolvedValue(undefined)
+  mockSyncRemove.mockResolvedValue(undefined)
+  mockLocalGet.mockResolvedValue({})
+  mockLocalSet.mockResolvedValue(undefined)
+})
+
+describe('pack group site rules', () => {
+  it('installs group settings when pack includes groupSettings', async () => {
+    const { usePacks } = await import('../src/composables/usePacks')
+    const { useShortcuts } = await import('../src/composables/useShortcuts')
+    const { installPack } = usePacks()
+    const { keys } = useShortcuts()
+
+    keys.value = []
+
+    await installPack({
+      id: 'crm-pack',
+      name: 'CRM Pack',
+      description: 'CRM shortcuts',
+      shortcuts: [
+        { key: 'meta+shift+k', action: 'javascript', label: 'Prev contact' },
+      ],
+      groupSettings: {
+        activateOn: 'https://app.example.com/*',
+      },
+    })
+
+    // Shortcuts should be added
+    expect(keys.value.length).toBe(1)
+    expect(keys.value[0].group).toBe('CRM Pack')
+
+    // Group settings should be saved to storage
+    const syncSetCalls = mockSyncSet.mock.calls
+    const groupSettingsCall = syncSetCalls.find(
+      (call: any[]) => call[0] && call[0].groupSettings
+    )
+    expect(groupSettingsCall).toBeTruthy()
+    const saved = JSON.parse(groupSettingsCall![0].groupSettings)
+    expect(saved['CRM Pack']).toBeDefined()
+    expect(saved['CRM Pack'].activateOn).toBe('https://app.example.com/*')
+  })
+
+  it('installs group settings with both activateOn and deactivateOn', async () => {
+    const { usePacks } = await import('../src/composables/usePacks')
+    const { useShortcuts } = await import('../src/composables/useShortcuts')
+    const { installPack } = usePacks()
+    const { keys } = useShortcuts()
+
+    keys.value = []
+
+    await installPack({
+      id: 'filtered-pack',
+      name: 'Filtered Pack',
+      description: 'Pack with both filters',
+      shortcuts: [
+        { key: 'alt+a', action: 'scrolldown', label: 'Scroll' },
+      ],
+      groupSettings: {
+        activateOn: 'https://app.example.com/*',
+        deactivateOn: 'https://app.example.com/admin*',
+      },
+    })
+
+    const syncSetCalls = mockSyncSet.mock.calls
+    const groupSettingsCall = syncSetCalls.find(
+      (call: any[]) => call[0] && call[0].groupSettings
+    )
+    expect(groupSettingsCall).toBeTruthy()
+    const saved = JSON.parse(groupSettingsCall![0].groupSettings)
+    expect(saved['Filtered Pack'].activateOn).toBe('https://app.example.com/*')
+    expect(saved['Filtered Pack'].deactivateOn).toBe('https://app.example.com/admin*')
+  })
+
+  it('does not write group settings when pack has no groupSettings', async () => {
+    const { usePacks } = await import('../src/composables/usePacks')
+    const { useShortcuts } = await import('../src/composables/useShortcuts')
+    const { installPack } = usePacks()
+    const { keys } = useShortcuts()
+
+    keys.value = []
+    vi.clearAllMocks()
+    mockSyncSet.mockResolvedValue(undefined)
+    mockLocalSet.mockResolvedValue(undefined)
+
+    await installPack({
+      id: 'plain-pack',
+      name: 'Plain Pack',
+      description: 'No site rules',
+      shortcuts: [
+        { key: 'alt+b', action: 'newtab', label: 'New tab' },
+      ],
+    })
+
+    // Only saveKeys should be called, not saveGroupSettings
+    const groupSettingsCall = mockSyncSet.mock.calls.find(
+      (call: any[]) => call[0] && call[0].groupSettings
+    )
+    expect(groupSettingsCall).toBeUndefined()
+  })
+
+  it('preserves existing group settings from other groups', async () => {
+    const { usePacks } = await import('../src/composables/usePacks')
+    const { useShortcuts } = await import('../src/composables/useShortcuts')
+    const { useGroups } = await import('../src/composables/useGroups')
+    const { installPack } = usePacks()
+    const { keys } = useShortcuts()
+    const { groupSettings } = useGroups()
+
+    keys.value = [{ key: 'alt+z', action: 'newtab', id: 'existing', group: 'Other Group', enabled: true } as any]
+    // Set up existing group settings (after beforeEach mock reset)
+    groupSettings['Other Group'] = { activateOn: 'https://other.com/*' }
+
+    await installPack({
+      id: 'new-pack',
+      name: 'New Pack',
+      description: 'Another pack',
+      shortcuts: [
+        { key: 'alt+c', action: 'closetab', label: 'Close' },
+      ],
+      groupSettings: {
+        activateOn: 'https://new.com/*',
+      },
+    })
+
+    // Both group settings should be in the reactive state
+    expect(groupSettings['New Pack']).toBeDefined()
+    expect(groupSettings['New Pack'].activateOn).toBe('https://new.com/*')
+    expect(groupSettings['Other Group']).toBeDefined()
+    expect(groupSettings['Other Group'].activateOn).toBe('https://other.com/*')
+  })
+})


### PR DESCRIPTION
Adds support for group-level `activateOn`/`deactivateOn` site rules in shortcut packs, so app-specific packs (like OnePageCRM) can restrict all their shortcuts to the relevant domain.

### Changes

- **`ShortcutPack` interface** — new optional `groupSettings` field with `activateOn`/`deactivateOn`
- **`installPack`** — writes group settings to storage when present in the pack
- **`useGroups`** — moved reactive state to module scope (singleton pattern, same as `useShortcuts`/`useToast`/`useJsTools`) so `groupSettings` is shared between `App.vue` and `usePacks`

### Example pack JSON

```json
{
  "name": "OnePageCRM",
  "description": "CRM shortcuts",
  "groupSettings": {
    "activateOn": "https://app.onepagecrm.com/*"
  },
  "shortcuts": [...]
}
```

### Tests

4 new tests (746 total):
1. Installs group settings when pack includes them
2. Handles both activateOn and deactivateOn
3. Skips group settings when pack doesn't include them
4. Preserves existing group settings from other groups

Related to #811