### PR TITLE
fix: wrap userScript injection in IIFE to avoid global leak

### DIFF
--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -52,7 +52,7 @@ export default defineBackground(() => {
           id: 'shortkeys-actions',
           matches: ['*://*/*'] as string[],
           world: 'MAIN' as const,
-          js: [{ code: `var handlers = ${handlersObj};\n(${registerHandlers.toString()})();` }],
+          js: [{ code: `(function(){var handlers = ${handlersObj};\n(${registerHandlers.toString()})();})();` }],
         },
       ]
 


### PR DESCRIPTION
Fixes #837

## Problem

The `userScripts.register()` call injected `var handlers = {...}` into the page's MAIN world as a **global variable**. This clobbered any existing `handlers` variable on the page — notably `alameda.js` (the AMD loader used by [Emby](https://github.com/MediaBrowser/Emby)), which uses `handlers.exports` internally, causing:

```
Uncaught TypeError: handlers.exports is not a function
    at main (alameda.js)
```

## Fix

Wrap the injected code in an IIFE so `var handlers` is function-scoped and doesn't leak into the global namespace. The closure still works — `registerHandlers` accesses `handlers` from the enclosing IIFE scope.

## Notes

This only affects users who have JavaScript-type shortcuts configured **and** have enabled "Allow User Scripts" in the extension details.