### PR TITLE
fix: preserve site restrictions in community pack export

### DIFF
--- a/src/composables/useImportExport.ts
+++ b/src/composables/useImportExport.ts
@@ -85,12 +85,13 @@ export function useImportExport() {
       icon: '📦',
       description: '',
       author: '',
-      shortcuts: groupShortcuts.map((s) => ({
-        key: s.key,
-        action: s.action,
-        label: s.label || s.action,
-        ...(s.code ? { code: s.code } : {}),
-      })),
+      shortcuts: groupShortcuts.map((s) => {
+        const { id, group: _g, enabled, ...rest } = s
+        return {
+          ...rest,
+          label: s.label || s.action,
+        }
+      }),
     }
 
     const json = JSON.stringify(packData, null, 2)


### PR DESCRIPTION
Fixes #811

## Problem

`publishToCommunity()` manually picked only `key`, `action`, `label`, and `code` from each shortcut. This stripped site restrictions (`sites`, `blacklist`, `sitesArray`), `activeInInputs`, `bookmark`, `openurl`, `trigger`, `macroSteps`, and other shortcut-level settings from community pack submissions.

## Fix

Spread all shortcut fields and only exclude internal/transient ones (`id`, `group`, `enabled`) which are set fresh on pack import.

Danny can now re-export his OnePageCRM pack with site restrictions intact.