### PR TITLE
fix: chunk sync storage to stay under per-item limit

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -8,28 +8,35 @@
  *   - QUOTA_BYTES_PER_ITEM: 8,192 bytes per key
  *   - QUOTA_BYTES: 102,400 bytes total
  *   - MAX_ITEMS: 512
+ *
+ * To stay under the per-item limit, shortcuts are split into chunks
+ * (keys_0, keys_1, ...) with a keys_meta entry storing the chunk count.
+ * The legacy single "keys" entry is supported for backward compatibility on load.
  */
 
 import { browser } from 'wxt/browser'
 
 const SYNC_QUOTA = 102_400 // 100KB total
+const SYNC_CHUNK_SIZE = 7_000 // Max chars per chunk (well under 8,192 byte per-item limit)
+const SYNC_CHUNK_PREFIX = 'keys_'
+const SYNC_META_KEY = 'keys_meta'
+const MAX_CHUNKS = 15 // 15 × 7KB = 105KB, above SYNC_QUOTA so this is safe
 const MIGRATED_KEY = '__shortkeys_migrated_to_sync'
 
 
 /**
- * Save keys to synced storage. Falls back to local if too large.
- * When falling back to local, clears stale sync data so loadKeys()
- * doesn't return an outdated dataset.
+ * Save keys to synced storage using chunked format.
+ * Falls back to local if too large for sync or if sync fails.
  * Returns 'sync' or 'local' indicating where data was saved.
  */
 export async function saveKeys(keys: any[]): Promise<'sync' | 'local'> {
   const json = JSON.stringify(keys)
   const byteSize = new Blob([json]).size
 
-  // If data fits in sync, use sync
-  if (browser.storage.sync && byteSize < SYNC_QUOTA - 1024) {
+  // If data fits in sync, use chunked sync
+  if (browser.storage.sync && byteSize < SYNC_QUOTA - 2048) {
     try {
-      await browser.storage.sync.set({ keys: json })
+      await saveToSyncChunked(json)
       // Also keep a local copy as backup
       await browser.storage.local.set({ keys: json })
       return 'sync'
@@ -40,13 +47,7 @@ export async function saveKeys(keys: any[]): Promise<'sync' | 'local'> {
 
   // Fallback: local only. Remove stale sync data so loadKeys() won't
   // return an older dataset that was saved before the data grew too large.
-  if (browser.storage.sync) {
-    try {
-      await browser.storage.sync.remove('keys')
-    } catch {
-      // Best-effort cleanup -- if this fails, loadKeys() still handles it
-    }
-  }
+  await clearSyncData()
   try {
     await browser.storage.local.set({ keys: json })
     return 'local'
@@ -56,8 +57,60 @@ export async function saveKeys(keys: any[]): Promise<'sync' | 'local'> {
   }
 }
 
+/** Split JSON string into chunks and write to sync storage. */
+async function saveToSyncChunked(json: string): Promise<void> {
+  const chunks: string[] = []
+  for (let i = 0; i < json.length; i += SYNC_CHUNK_SIZE) {
+    chunks.push(json.slice(i, i + SYNC_CHUNK_SIZE))
+  }
+
+  const payload: Record<string, any> = { [SYNC_META_KEY]: chunks.length }
+  chunks.forEach((chunk, i) => { payload[`${SYNC_CHUNK_PREFIX}${i}`] = chunk })
+  await browser.storage.sync.set(payload)
+
+  // Clean up legacy single "keys" entry and any excess chunks from a previous save
+  const toRemove = ['keys']
+  for (let i = chunks.length; i < MAX_CHUNKS; i++) {
+    toRemove.push(`${SYNC_CHUNK_PREFIX}${i}`)
+  }
+  try { await browser.storage.sync.remove(toRemove) } catch { /* best-effort */ }
+}
+
+/** Load keys from chunked sync storage. Returns undefined if no chunked data. */
+async function loadFromSyncChunked(): Promise<string | undefined> {
+  const metaData = await browser.storage.sync.get(SYNC_META_KEY)
+  const chunkCount = metaData[SYNC_META_KEY] as number | undefined
+  if (!chunkCount || chunkCount < 1) return undefined
+
+  const chunkKeys = Array.from({ length: chunkCount }, (_, i) => `${SYNC_CHUNK_PREFIX}${i}`)
+  const chunkData = await browser.storage.sync.get(chunkKeys)
+
+  let json = ''
+  for (let i = 0; i < chunkCount; i++) {
+    const chunk = chunkData[`${SYNC_CHUNK_PREFIX}${i}`]
+    if (chunk === undefined) return undefined // Missing chunk — data is corrupted
+    json += chunk
+  }
+
+  return json
+}
+
+/** Remove all sync data (meta, chunks, and legacy "keys" entry). */
+async function clearSyncData(): Promise<void> {
+  if (!browser.storage.sync) return
+  try {
+    const toRemove = ['keys', SYNC_META_KEY]
+    for (let i = 0; i < MAX_CHUNKS; i++) {
+      toRemove.push(`${SYNC_CHUNK_PREFIX}${i}`)
+    }
+    await browser.storage.sync.remove(toRemove)
+  } catch {
+    // Best-effort cleanup
+  }
+}
+
 /**
- * Load keys from storage. Checks sync first, then local.
+ * Load keys from storage. Checks sync first (chunked, then legacy), then local.
  * If both exist, compares them and returns whichever has more shortcuts
  * (more data = more recent, since shortcuts only grow via import/add).
  */
@@ -65,11 +118,14 @@ export async function loadKeys(): Promise<string | undefined> {
   let syncKeys: string | undefined
   let localKeys: string | undefined
 
-  // Try sync first
+  // Try sync first: chunked format, then legacy single-key format
   if (browser.storage.sync) {
     try {
-      const syncData = await browser.storage.sync.get('keys')
-      syncKeys = syncData.keys as string | undefined
+      syncKeys = await loadFromSyncChunked()
+      if (!syncKeys) {
+        const syncData = await browser.storage.sync.get('keys')
+        syncKeys = syncData.keys as string | undefined
+      }
     } catch (e) {
       console.error('[Shortkeys] Failed to load from sync storage, trying local:', e)
     }
@@ -122,17 +178,23 @@ export async function migrateLocalToSync(): Promise<void> {
       return
     }
 
+    // Check if sync already has data (chunked or legacy)
+    const existingSync = await loadFromSyncChunked()
+    if (existingSync) {
+      await browser.storage.local.set({ [MIGRATED_KEY]: true })
+      return
+    }
     const syncData = await browser.storage.sync.get('keys')
     if (syncData.keys) {
-      // Sync already has data -- don't overwrite (user may have set up on another device)
       await browser.storage.local.set({ [MIGRATED_KEY]: true })
       return
     }
 
-    // Migrate local -> sync
-    const byteSize = new Blob([localData.keys as string]).size
-    if (byteSize < SYNC_QUOTA - 1024) {
-      await browser.storage.sync.set({ keys: localData.keys })
+    // Migrate local -> sync using chunked format
+    const json = localData.keys as string
+    const byteSize = new Blob([json]).size
+    if (byteSize < SYNC_QUOTA - 2048) {
+      await saveToSyncChunked(json)
     }
     await browser.storage.local.set({ [MIGRATED_KEY]: true })
   } catch (e) {

--- a/tests/popup-quick-add.test.ts
+++ b/tests/popup-quick-add.test.ts
@@ -58,7 +58,11 @@ describe('popup quick-add shortcut flow', () => {
     const existing: KeySetting[] = [
       { key: 'ctrl+b', action: 'newtab', id: 'existing-1', enabled: true },
     ]
-    mockSyncGet.mockResolvedValue({ keys: JSON.stringify(existing) })
+    mockSyncGet.mockImplementation((keys: any) => {
+      if (keys === 'keys_meta') return Promise.resolve({})
+      if (keys === 'keys') return Promise.resolve({ keys: JSON.stringify(existing) })
+      return Promise.resolve({})
+    })
 
     // Simulate the quick-add save flow
     const saved = await loadKeys()
@@ -78,9 +82,9 @@ describe('popup quick-add shortcut flow', () => {
     expect(currentKeys[0].id).toBe('existing-1')
     expect(currentKeys[1].key).toBe('ctrl+shift+k')
     expect(currentKeys[1].action).toBe('closetab')
-    expect(mockSyncSet).toHaveBeenCalledWith({
-      keys: JSON.stringify(currentKeys),
-    })
+    expect(mockSyncSet).toHaveBeenCalledWith(
+      expect.objectContaining({ keys_meta: 1, keys_0: JSON.stringify(currentKeys) })
+    )
   })
 
   it('creates shortcut with empty storage (first shortcut)', async () => {
@@ -102,9 +106,9 @@ describe('popup quick-add shortcut flow', () => {
     await saveKeys(currentKeys)
 
     expect(currentKeys).toHaveLength(1)
-    expect(mockSyncSet).toHaveBeenCalledWith({
-      keys: JSON.stringify([newShortcut]),
-    })
+    expect(mockSyncSet).toHaveBeenCalledWith(
+      expect.objectContaining({ keys_meta: 1, keys_0: JSON.stringify([newShortcut]) })
+    )
   })
 
   it('does not save when key is empty', () => {

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -33,14 +33,49 @@ beforeEach(() => {
 })
 
 describe('saveKeys', () => {
-  it('saves to sync when data fits', async () => {
+  it('saves to sync in chunked format when data fits', async () => {
     const keys = [{ key: 'ctrl+b', action: 'newtab' }]
     const result = await saveKeys(keys)
 
     expect(result).toBe('sync')
-    expect(mockSyncSet).toHaveBeenCalledWith({ keys: JSON.stringify(keys) })
+    // Should save chunked: keys_meta + keys_0
+    expect(mockSyncSet).toHaveBeenCalledWith(
+      expect.objectContaining({ keys_meta: 1, keys_0: JSON.stringify(keys) })
+    )
     // Also saves local backup
     expect(mockLocalSet).toHaveBeenCalledWith({ keys: JSON.stringify(keys) })
+  })
+
+  it('splits large data into multiple chunks', async () => {
+    // Create data larger than 7,000 chars but under 102KB
+    const keys = Array.from({ length: 50 }, (_, i) => ({
+      key: `ctrl+${i}`, action: 'javascript', code: 'x'.repeat(200), label: `Shortcut ${i}`
+    }))
+    const json = JSON.stringify(keys)
+    expect(json.length).toBeGreaterThan(7000)
+
+    const result = await saveKeys(keys)
+
+    expect(result).toBe('sync')
+    const setCall = mockSyncSet.mock.calls[0][0]
+    expect(setCall.keys_meta).toBeGreaterThan(1)
+    // Reassemble chunks should equal original JSON
+    let reassembled = ''
+    for (let i = 0; i < setCall.keys_meta; i++) {
+      expect(setCall[`keys_${i}`]).toBeDefined()
+      expect(setCall[`keys_${i}`].length).toBeLessThanOrEqual(7000)
+      reassembled += setCall[`keys_${i}`]
+    }
+    expect(reassembled).toBe(json)
+  })
+
+  it('cleans up legacy "keys" entry and excess chunks after saving', async () => {
+    const keys = [{ key: 'a', action: 'newtab' }]
+    await saveKeys(keys)
+
+    expect(mockSyncRemove).toHaveBeenCalledWith(
+      expect.arrayContaining(['keys'])
+    )
   })
 
   it('falls back to local when sync fails', async () => {
@@ -84,25 +119,30 @@ describe('saveKeys', () => {
     consoleSpy.mockRestore()
   })
 
-  it('clears stale sync data when falling back to local after sync failure', async () => {
+  it('clears all sync data when falling back to local', async () => {
     mockSyncSet.mockRejectedValue(new Error('quota exceeded'))
     const keys = [{ key: 'a', action: 'newtab' }]
     await saveKeys(keys)
 
-    expect(mockSyncRemove).toHaveBeenCalledWith('keys')
+    // Should clear legacy key, meta, and chunk keys
+    expect(mockSyncRemove).toHaveBeenCalledWith(
+      expect.arrayContaining(['keys', 'keys_meta', 'keys_0'])
+    )
     expect(mockLocalSet).toHaveBeenCalledWith({ keys: JSON.stringify(keys) })
   })
 
-  it('clears stale sync data when data is too large for sync', async () => {
+  it('clears all sync data when data is too large for sync', async () => {
     const bigCode = 'x'.repeat(110_000)
     const keys = [{ key: 'a', action: 'javascript', code: bigCode }]
     await saveKeys(keys)
 
-    expect(mockSyncRemove).toHaveBeenCalledWith('keys')
+    expect(mockSyncRemove).toHaveBeenCalledWith(
+      expect.arrayContaining(['keys', 'keys_meta'])
+    )
     expect(mockLocalSet).toHaveBeenCalled()
   })
 
-  it('still saves to local if sync.remove fails', async () => {
+  it('still saves to local if sync.remove fails during cleanup', async () => {
     mockSyncSet.mockRejectedValue(new Error('quota exceeded'))
     mockSyncRemove.mockRejectedValue(new Error('remove failed'))
     const keys = [{ key: 'a', action: 'newtab' }]
@@ -114,12 +154,40 @@ describe('saveKeys', () => {
 })
 
 describe('loadKeys', () => {
-  it('loads from sync first', async () => {
-    mockSyncGet.mockResolvedValue({ keys: '[{"key":"a"}]' })
+  it('loads from sync chunked format', async () => {
+    const json = '[{"key":"a"}]'
+    mockSyncGet.mockImplementation((keys: any) => {
+      if (keys === 'keys_meta') return Promise.resolve({ keys_meta: 1 })
+      if (Array.isArray(keys) && keys.includes('keys_0')) return Promise.resolve({ keys_0: json })
+      return Promise.resolve({})
+    })
     const result = await loadKeys()
 
-    expect(result).toBe('[{"key":"a"}]')
-    expect(mockSyncGet).toHaveBeenCalledWith('keys')
+    expect(result).toBe(json)
+  })
+
+  it('loads from sync chunked format with multiple chunks', async () => {
+    const chunk0 = '[{"key":"a"},'
+    const chunk1 = '{"key":"b"}]'
+    mockSyncGet.mockImplementation((keys: any) => {
+      if (keys === 'keys_meta') return Promise.resolve({ keys_meta: 2 })
+      if (Array.isArray(keys)) return Promise.resolve({ keys_0: chunk0, keys_1: chunk1 })
+      return Promise.resolve({})
+    })
+    const result = await loadKeys()
+
+    expect(result).toBe(chunk0 + chunk1)
+  })
+
+  it('falls back to legacy single "keys" format if no chunks', async () => {
+    mockSyncGet.mockImplementation((keys: any) => {
+      if (keys === 'keys_meta') return Promise.resolve({})
+      if (keys === 'keys') return Promise.resolve({ keys: '[{"key":"legacy"}]' })
+      return Promise.resolve({})
+    })
+    const result = await loadKeys()
+
+    expect(result).toBe('[{"key":"legacy"}]')
   })
 
   it('falls back to local if sync is empty', async () => {
@@ -160,9 +228,24 @@ describe('loadKeys', () => {
     consoleSpy.mockRestore()
   })
 
-  it('prefers local when local has more shortcuts than sync (stale sync)', async () => {
-    // Simulate stale sync: sync has 1 shortcut, local has 3 (user added more after exceeding sync quota)
-    mockSyncGet.mockResolvedValue({ keys: '[{"key":"a"}]' })
+  it('returns undefined if a chunk is missing (corrupted)', async () => {
+    mockSyncGet.mockImplementation((keys: any) => {
+      if (keys === 'keys_meta') return Promise.resolve({ keys_meta: 2 })
+      if (Array.isArray(keys)) return Promise.resolve({ keys_0: 'data' }) // keys_1 missing
+      return Promise.resolve({})
+    })
+    mockLocalGet.mockResolvedValue({})
+    const result = await loadKeys()
+
+    expect(result).toBeUndefined()
+  })
+
+  it('prefers local when local has more shortcuts than sync', async () => {
+    mockSyncGet.mockImplementation((keys: any) => {
+      if (keys === 'keys_meta') return Promise.resolve({ keys_meta: 1 })
+      if (Array.isArray(keys)) return Promise.resolve({ keys_0: '[{"key":"a"}]' })
+      return Promise.resolve({})
+    })
     mockLocalGet.mockResolvedValue({ keys: '[{"key":"a"},{"key":"b"},{"key":"c"}]' })
     const result = await loadKeys()
 
@@ -170,7 +253,11 @@ describe('loadKeys', () => {
   })
 
   it('prefers sync when sync has more shortcuts than local', async () => {
-    mockSyncGet.mockResolvedValue({ keys: '[{"key":"a"},{"key":"b"}]' })
+    mockSyncGet.mockImplementation((keys: any) => {
+      if (keys === 'keys_meta') return Promise.resolve({ keys_meta: 1 })
+      if (Array.isArray(keys)) return Promise.resolve({ keys_0: '[{"key":"a"},{"key":"b"}]' })
+      return Promise.resolve({})
+    })
     mockLocalGet.mockResolvedValue({ keys: '[{"key":"a"}]' })
     const result = await loadKeys()
 
@@ -178,8 +265,11 @@ describe('loadKeys', () => {
   })
 
   it('prefers local when both have equal number of shortcuts', async () => {
-    // When equal, prefer local (it was written more recently in the fallback path)
-    mockSyncGet.mockResolvedValue({ keys: '[{"key":"a"}]' })
+    mockSyncGet.mockImplementation((keys: any) => {
+      if (keys === 'keys_meta') return Promise.resolve({ keys_meta: 1 })
+      if (Array.isArray(keys)) return Promise.resolve({ keys_0: '[{"key":"a"}]' })
+      return Promise.resolve({})
+    })
     mockLocalGet.mockResolvedValue({ keys: '[{"key":"b"}]' })
     const result = await loadKeys()
 
@@ -188,23 +278,47 @@ describe('loadKeys', () => {
 })
 
 describe('migrateLocalToSync', () => {
-  it('copies local data to sync on first run', async () => {
+  it('copies local data to sync using chunked format on first run', async () => {
     mockLocalGet
       .mockResolvedValueOnce({ }) // no migration flag
       .mockResolvedValueOnce({ keys: '[{"key":"a"}]' }) // local data
-    mockSyncGet.mockResolvedValue({}) // sync is empty
+    mockSyncGet.mockResolvedValue({}) // sync is empty (no chunks, no legacy)
 
     await migrateLocalToSync()
 
-    expect(mockSyncSet).toHaveBeenCalledWith({ keys: '[{"key":"a"}]' })
+    // Should use chunked format
+    expect(mockSyncSet).toHaveBeenCalledWith(
+      expect.objectContaining({ keys_meta: 1, keys_0: '[{"key":"a"}]' })
+    )
     expect(mockLocalSet).toHaveBeenCalledWith({ __shortkeys_migrated_to_sync: true })
   })
 
-  it('does not overwrite existing sync data', async () => {
+  it('does not overwrite existing chunked sync data', async () => {
     mockLocalGet
       .mockResolvedValueOnce({}) // no migration flag
       .mockResolvedValueOnce({ keys: '[{"key":"local"}]' })
-    mockSyncGet.mockResolvedValue({ keys: '[{"key":"sync"}]' }) // sync already has data
+    // Sync has chunked data
+    mockSyncGet.mockImplementation((keys: any) => {
+      if (keys === 'keys_meta') return Promise.resolve({ keys_meta: 1 })
+      if (Array.isArray(keys)) return Promise.resolve({ keys_0: '[{"key":"sync"}]' })
+      return Promise.resolve({})
+    })
+
+    await migrateLocalToSync()
+
+    expect(mockSyncSet).not.toHaveBeenCalled()
+    expect(mockLocalSet).toHaveBeenCalledWith({ __shortkeys_migrated_to_sync: true })
+  })
+
+  it('does not overwrite existing legacy sync data', async () => {
+    mockLocalGet
+      .mockResolvedValueOnce({}) // no migration flag
+      .mockResolvedValueOnce({ keys: '[{"key":"local"}]' })
+    mockSyncGet.mockImplementation((keys: any) => {
+      if (keys === 'keys_meta') return Promise.resolve({}) // no chunks
+      if (keys === 'keys') return Promise.resolve({ keys: '[{"key":"sync"}]' }) // legacy
+      return Promise.resolve({})
+    })
 
     await migrateLocalToSync()
 


### PR DESCRIPTION
Fixes #848

## Problem

`chrome.storage.sync` has an **8,192 byte per-item limit**. All shortcuts were stored as a single JSON string under the key `"keys"`, which hit this limit with ~23 shortcuts. Users saw "Shortcuts saved locally — too large to sync" even though total data was well under the 100KB total quota.

## Solution

Split the JSON string into **7KB chunks** stored as `keys_0`, `keys_1`, etc., with a `keys_meta` entry storing the chunk count. This keeps each item well under the 8,192 byte limit while allowing up to ~100KB total sync capacity (~14 chunks).

### How it works

**Saving:**
1. Serialize shortcuts to JSON
2. If total size < 100KB, split into 7KB chunks and write all chunks + meta to sync
3. Clean up legacy `keys` entry and any excess chunks from previous saves
4. If total > 100KB, fall back to local-only (same as before)

**Loading:**
1. Check for chunked format (`keys_meta`) first
2. Fall back to legacy single `keys` format (backward compatible)
3. Then check local storage
4. Return whichever source has more shortcuts

### Backward compatibility
- Existing users with the old single `keys` format will load fine — `loadKeys()` checks both formats
- On next save, data is automatically written in chunked format
- Migration (`migrateLocalToSync`) also uses chunked format now

### Tests
- 748 tests pass (6 new: chunking, multi-chunk reassembly, legacy fallback, missing chunk detection, migration with chunks)