### PR TITLE
BUG: link hints (new tab) opens and immediately closes — missing return

### DIFF
--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -60,6 +60,8 @@ export default defineContentScript({
       }
       if (action === 'linkhintsnew') {
         activateLinkHints(true)
+        trackContentAction(keySetting)
+        return
       }
       if (action === 'editurl') {
         showEditUrlBar()


### PR DESCRIPTION
Hi, I think it's just a simple fluke, but it does break the open link hints in a new tab function. I can't use it, traced back here.