### PR TITLE
allow overlay actions while typing

### DIFF
--- a/src/utils/content-logic.ts
+++ b/src/utils/content-logic.ts
@@ -1,6 +1,19 @@
 import type { KeySetting } from './url-matching'
 
 /**
+ * Content-script actions that bypass the activeInInputs check.
+ * These show overlays or toggle CSS — they never insert text into
+ * the active element, so allowing them in inputs is safe.
+ */
+export const OVERLAY_ACTIONS = [
+  'linkhints',
+  'linkhintsnew',
+  'showcheatsheet',
+  'toggledarkmode',
+  'editurl',
+]
+
+/**
  * Fetch the full key shortcut config given a keyboard combo.
  */
 export function fetchConfig(keys: KeySetting[], keyCombo: string): KeySetting | false {
@@ -28,6 +41,8 @@ export function shouldStopCallback(
 
   if (element.classList && element.classList.contains('mousetrap')) {
     return true
+  } else if (keySetting && OVERLAY_ACTIONS.includes(keySetting.action)) {
+    return false
   } else if (!keySetting || !keySetting.activeInInputs) {
     const role = element.getAttribute?.('role')
     return (


### PR DESCRIPTION
Content-script actions that should always fire, even when focused in a form input. All of these show UI overlays (or toggle CSS) and never insert text or modify the active element, so they're safe to allow:
 
    linkhints/new    — overlay for clicking links by keyboard
    showcheatsheet   — overlay listing all shortcuts
    toggledarkmode   — injects/removes a <style> element
    editurl          — shows a command bar overlay
 
Without this, users in text fields can't activate link hints (a keyboard-driven mouse replacement) without first reaching for the mouse to click outside the input — defeating the purpose.